### PR TITLE
fix package not found bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pycollada==0.6
 Pillow
+rospkg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pycollada==0.6
 Pillow
-rospkg

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
     install_requires=[
         "pycollada >= 0.6",
         "Pillow",
-        "numpy"
+        "numpy",
+        "rospkg"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='urdf2webots',
-    version='1.0.0',
+    version='1.0.1',
     author='Cyberbotics',
     author_email='support@cyberbotics.com',
     description='A converter between URDF and PROTO files.',

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -58,8 +58,8 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
                 directory = rospack.get_path(packageName)
             except rospkg.common.ResourceNotFound:
                 sys.stderr.write('Package "%s" not found.\n' % packageName)
-            while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
-                directory = os.path.dirname(directory)
+            # while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
+            #     directory = os.path.dirname(directory)
             if os.path.split(directory)[1]:
                 packagePath = os.path.split(directory)[0]
                 content = content.replace('package:/', packagePath)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -53,13 +53,16 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
         packages = re.findall('"package://(.*)"', content)
         if packages:
             packageName = packages[0].split('/')[0]
-            try:
-                rospack = rospkg.RosPack()
-                directory = rospack.get_path(packageName)
-            except rospkg.common.ResourceNotFound:
-                sys.stderr.write('Package "%s" not found.\n' % packageName)
-            # while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
-            #     directory = os.path.dirname(directory)
+            # try:
+            #     rospack = rospkg.RosPack()
+            #     directory = rospack.get_path(packageName)
+            # except rospkg.common.ResourceNotFound:
+            #     sys.stderr.write('Package "%s" not found.\n' % packageName)
+            directory = os.path.dirname(inFile)
+            print(directory)
+            while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
+                directory = os.path.dirname(directory)
+            print(directory)
             if os.path.split(directory)[1]:
                 packagePath = os.path.split(directory)[0]
                 content = content.replace('package:/', packagePath)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -11,7 +11,8 @@ import sys
 import urdf2webots.parserURDF
 import urdf2webots.writeProto
 from xml.dom import minidom
-
+import rospkg
+rospack = rospkg.RosPack()
 
 def convertLUtoUN(s):
     """Capitalize a string."""
@@ -49,11 +50,10 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
 
     with open(inFile, 'r') as file:
         content = file.read()
-
         packages = re.findall('"package://(.*)"', content)
         if packages:
             packageName = packages[0].split('/')[0]
-            directory = os.path.dirname(inFile)
+            directory = rospack.get_path(packageName)
             while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
                 directory = os.path.dirname(directory)
             if os.path.split(directory)[1]:

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -12,7 +12,7 @@ import urdf2webots.parserURDF
 import urdf2webots.writeProto
 from xml.dom import minidom
 import rospkg
-rospack = rospkg.RosPack()
+
 
 def convertLUtoUN(s):
     """Capitalize a string."""
@@ -53,7 +53,11 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
         packages = re.findall('"package://(.*)"', content)
         if packages:
             packageName = packages[0].split('/')[0]
-            directory = rospack.get_path(packageName)
+            try:
+                rospack = rospkg.RosPack()
+                directory = rospack.get_path(packageName)
+            except rospack.ResourceNotFound:
+                sys.stderr.write('Package "%s" not found.\n' % packageName)
             while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
                 directory = os.path.dirname(directory)
             if os.path.split(directory)[1]:

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -11,7 +11,11 @@ import sys
 import urdf2webots.parserURDF
 import urdf2webots.writeProto
 from xml.dom import minidom
-import rospkg
+
+try:
+    import rospkg
+except ImportError:
+    pass
 
 
 def convertLUtoUN(s):
@@ -56,12 +60,12 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
             directory = os.path.dirname(inFile)
             while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
                 directory = os.path.dirname(directory)
-            if not os.path.split(directory)[1]:
-                try:
-                    rospack = rospkg.RosPack()
-                    directory = rospack.get_path(packageName)
-                except rospkg.common.ResourceNotFound:
-                    sys.stderr.write('Package "%s" not found.\n' % packageName)
+            #if not os.path.split(directory)[1]:
+            try:
+                rospack = rospkg.RosPack()
+                directory = rospack.get_path(packageName)
+            except rospkg.common.ResourceNotFound:
+                sys.stderr.write('Package "%s" not found.\n' % packageName)
             if os.path.split(directory)[1]:
                 packagePath = os.path.split(directory)[0]
                 content = content.replace('package:/', packagePath)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -56,7 +56,7 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
             try:
                 rospack = rospkg.RosPack()
                 directory = rospack.get_path(packageName)
-            except rospack.ResourceNotFound:
+            except rospkg.common.ResourceNotFound:
                 sys.stderr.write('Package "%s" not found.\n' % packageName)
             while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
                 directory = os.path.dirname(directory)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -60,12 +60,14 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
             directory = os.path.dirname(inFile)
             while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
                 directory = os.path.dirname(directory)
-            #if not os.path.split(directory)[1]:
-            try:
-                rospack = rospkg.RosPack()
-                directory = rospack.get_path(packageName)
-            except rospkg.common.ResourceNotFound:
-                sys.stderr.write('Package "%s" not found.\n' % packageName)
+            if not os.path.split(directory)[1]:
+                try:
+                    rospack = rospkg.RosPack()
+                    directory = rospack.get_path(packageName)
+                except rospkg.common.ResourceNotFound:
+                    sys.stderr.write('Package "%s" not found.\n' % packageName)
+                except NameError:
+                    sys.stderr.write('Impossible to find location of "%s" package, installing "rospkg" might help.\n' % packageName)
             if os.path.split(directory)[1]:
                 packagePath = os.path.split(directory)[0]
                 content = content.replace('package:/', packagePath)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -53,16 +53,15 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
         packages = re.findall('"package://(.*)"', content)
         if packages:
             packageName = packages[0].split('/')[0]
-            # try:
-            #     rospack = rospkg.RosPack()
-            #     directory = rospack.get_path(packageName)
-            # except rospkg.common.ResourceNotFound:
-            #     sys.stderr.write('Package "%s" not found.\n' % packageName)
             directory = os.path.dirname(inFile)
-            print(directory)
             while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
                 directory = os.path.dirname(directory)
-            print(directory)
+            if not os.path.split(directory)[1]:
+                try:
+                    rospack = rospkg.RosPack()
+                    directory = rospack.get_path(packageName)
+                except rospkg.common.ResourceNotFound:
+                    sys.stderr.write('Package "%s" not found.\n' % packageName)
             if os.path.split(directory)[1]:
                 packagePath = os.path.split(directory)[0]
                 content = content.replace('package:/', packagePath)


### PR DESCRIPTION
When using the urdf2webots tool the ROS packages were not found.(To load .stl files) 

`Can't determine package root path.
Robot name: turtlebot3_burger
Parsing Mesh: turtlebot3_description/meshes/bases/burger_base.stl
Traceback (most recent call last):
  File "demo.py", line 18, in <module>
    convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization)
  File "/home/vidicon/Documents/git/urdf2webots/urdf2webots/importer.py", line 103, in convert2urdf
    linkList.append(urdf2webots.parserURDF.getLink(link))
  File "/home/vidicon/Documents/git/urdf2webots/urdf2webots/parserURDF.py", line 768, in getLink
    getVisual(link, node)
  File "/home/vidicon/Documents/git/urdf2webots/urdf2webots/parserURDF.py", line 642, in getVisual
    visual = getSTLMesh(meshfile, visual)
  File "/home/vidicon/Documents/git/urdf2webots/urdf2webots/parserURDF.py", line 374, in getSTLMesh
    stlFile = open(filename, 'rb')
IOError: [Errno 2] No such file or directory: u'turtlebot3_description/meshes/bases/burger_base.stl'
`

This PR fixes that issue. For that, it uses the [RosPack class](https://wiki.ros.org/Packages#Client_Library_Support)