### PR TITLE
Add support for OBJ meshes

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -10,9 +10,13 @@ from urdf2webots.importer import convert2urdf
 optParser = optparse.OptionParser(usage='usage: %prog --input=my_robot.urdf [options]')
 optParser.add_option('--input', dest='inFile', default='', help='Specifies the urdf file to convert.')
 optParser.add_option('--output', dest='outFile', default='', help='Specifies the name of the resulting PROTO file.')
-optParser.add_option('--normal', dest='normal', action='store_true', default=False, help='If set, the normals are exported if present in the URDF definition.')
-optParser.add_option('--box-collision', dest='boxCollision', action='store_true', default=False, help='If set, the bounding objects are approximated using boxes.')
-optParser.add_option('--disable-mesh-optimization', dest='disableMeshOptimization', action='store_true', default=False, help='If set, the duplicated vertices are not removed from the meshes (this can speed up a lot the conversion).')
+optParser.add_option('--normal', dest='normal', action='store_true', default=False,
+                     help='If set, the normals are exported if present in the URDF definition.')
+optParser.add_option('--box-collision', dest='boxCollision', action='store_true', default=False,
+                     help='If set, the bounding objects are approximated using boxes.')
+optParser.add_option('--disable-mesh-optimization', dest='disableMeshOptimization', action='store_true', default=False,
+                     help='If set, the duplicated vertices are not removed from the meshes (this can speed up a lot the '
+                     'conversion).')
 options, args = optParser.parse_args()
 
 convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='urdf2webots',
-    version='1.0.1',
+    version='1.0.2',
     author='Cyberbotics',
     author_email='support@cyberbotics.com',
     description='A converter between URDF and PROTO files.',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='urdf2webots',
-    version='1.0.2',
+    version='1.0.1',
     author='Cyberbotics',
     author_email='support@cyberbotics.com',
     description='A converter between URDF and PROTO files.',

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -48,6 +48,7 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
     urdf2webots.parserURDF.disableMeshOptimization = disableMeshOptimization
 
     with open(inFile, 'r') as file:
+        inPath = os.path.dirname(os.path.abspath(inFile))
         content = file.read()
 
         packages = re.findall('"package://(.*)"', content)
@@ -96,12 +97,12 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
 
                 for joint in jointElementList:
                     jointList.append(urdf2webots.parserURDF.getJoint(joint))
-                    parentList.append(jointList[-1].parent.encode('ascii'))
-                    childList.append(jointList[-1].child.encode('ascii'))
+                    parentList.append(jointList[-1].parent)
+                    childList.append(jointList[-1].child)
                 parentList.sort()
                 childList.sort()
                 for link in linkElementList:
-                    linkList.append(urdf2webots.parserURDF.getLink(link))
+                    linkList.append(urdf2webots.parserURDF.getLink(link, inPath))
                 for link in linkList:
                     if urdf2webots.parserURDF.isRootLink(link.name, childList):
                         rootLink = link

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -83,7 +83,8 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
                     elif child.localName == 'joint':
                         jointElementList.append(child)
                     elif child.localName == 'material':
-                        if not child.hasAttribute('name') or child.getAttribute('name') not in urdf2webots.parserURDF.Material.namedMaterial:
+                        if not child.hasAttribute('name') \
+                           or child.getAttribute('name') not in urdf2webots.parserURDF.Material.namedMaterial:
                             material = urdf2webots.parserURDF.Material()
                             material.parseFromMaterialNode(child)
 
@@ -129,7 +130,9 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False, disable
                     if child.localName == 'gazebo':
                         urdf2webots.parserURDF.parseGazeboElement(child, rootLink.name, linkList)
 
-                sensorList = urdf2webots.parserURDF.IMU.list + urdf2webots.parserURDF.Camera.list + urdf2webots.parserURDF.Lidar.list
+                sensorList = (urdf2webots.parserURDF.IMU.list +
+                              urdf2webots.parserURDF.Camera.list +
+                              urdf2webots.parserURDF.Lidar.list)
                 print('There are %d links, %d joints and %d sensors' % (len(linkList), len(jointList), len(sensorList)))
 
                 urdf2webots.writeProto.declaration(protoFile, robotName)
@@ -145,10 +148,13 @@ if __name__ == '__main__':
     optParser = optparse.OptionParser(usage='usage: %prog --input=my_robot.urdf [options]')
     optParser.add_option('--input', dest='inFile', default='', help='Specifies the urdf file to convert.')
     optParser.add_option('--output', dest='outFile', default='', help='Specifies the name of the resulting PROTO file.')
-    optParser.add_option('--normal', dest='normal', action='store_true', default=False, help='If set, the normals are exported if present in the URDF definition.')
-    optParser.add_option('--box-collision', dest='boxCollision', action='store_true', default=False, help='If set, the bounding objects are approximated using boxes.')
+    optParser.add_option('--normal', dest='normal', action='store_true', default=False,
+                         help='If set, the normals are exported if present in the URDF definition.')
+    optParser.add_option('--box-collision', dest='boxCollision', action='store_true', default=False,
+                         help='If set, the bounding objects are approximated using boxes.')
     optParser.add_option('--disable-mesh-optimization', dest='disableMeshOptimization', action='store_true', default=False,
-                         help='If set, the duplicated vertices are not removed from the meshes (this can speed up a lot the conversion).')
+                         help='If set, the duplicated vertices are not removed from the meshes (this can speed up a lot the '
+                         'conversion).')
     options, args = optParser.parse_args()
 
     convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization)

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -250,17 +250,20 @@ class IMU():
         file.write(indentationLevel * indent + 'Accelerometer {\n')
         file.write(indentationLevel * indent + '  name "%s accelerometer"\n' % self.name)
         if self.gaussianNoise > 0:
-            file.write(indentationLevel * indent + '  lookupTable [-100 -100 %lf, 100 100 %lf]\n' % (-self.gaussianNoise / 100.0, self.gaussianNoise / 100.0))
+            file.write(indentationLevel * indent + '  lookupTable [-100 -100 %lf, 100 100 %lf]\n' %
+                       (-self.gaussianNoise / 100.0, self.gaussianNoise / 100.0))
         file.write(indentationLevel * indent + '}\n')
         file.write(indentationLevel * indent + 'Gyro {\n')
         file.write(indentationLevel * indent + '  name "%s gyro"\n' % self.name)
         if self.gaussianNoise > 0:
-            file.write(indentationLevel * indent + '  lookupTable [-100 -100 %lf, 100 100 %lf]\n' % (-self.gaussianNoise / 100.0, self.gaussianNoise / 100.0))
+            file.write(indentationLevel * indent + '  lookupTable [-100 -100 %lf, 100 100 %lf]\n' %
+                       (-self.gaussianNoise / 100.0, self.gaussianNoise / 100.0))
         file.write(indentationLevel * indent + '}\n')
         file.write(indentationLevel * indent + 'Compass {\n')
         file.write(indentationLevel * indent + '  name "%s compass"\n' % self.name)
         if self.gaussianNoise > 0:
-            file.write(indentationLevel * indent + '  lookupTable [-1 -1 %lf, 1 1 %lf]\n' % -self.gaussianNoise, self.gaussianNoise)
+            file.write(indentationLevel * indent + '  lookupTable [-1 -1 %lf, 1 1 %lf]\n' %
+                       -self.gaussianNoise, self.gaussianNoise)
         file.write(indentationLevel * indent + '}\n')
 
 
@@ -471,7 +474,8 @@ def getColladaMesh(filename, node, link):
                             visual.material.diffuse = colorVector2Instance(data.material.effect.diffuse)
                         else:
                             # diffuse is defined by *.tif files
-                            visual.material.texture = 'textures/' + data.material.effect.diffuse.sampler.surface.image.path.split('/')[-1]
+                            visual.material.texture = 'textures/' + \
+                                                      data.material.effect.diffuse.sampler.surface.image.path.split('/')[-1]
                             txt = os.path.splitext(visual.material.texture)[1]
                             if txt == '.tiff' or txt == '.tif':
                                 for dirname, dirnames, filenames in os.walk('.'):
@@ -481,7 +485,8 @@ def getColladaMesh(filename, node, link):
                                                 tifImage = Image.open(os.path.join(dirname, file))
                                                 img = './' + robotName + '_textures'
                                                 tifImage.save(os.path.splitext(os.path.join(img, file))[0] + '.png')
-                                                visual.material.texture = robotName + '_textures/' + os.path.splitext(file)[0] + '.png'
+                                                visual.material.texture = (robotName +
+                                                                           '_textures/' + os.path.splitext(file)[0] + '.png')
                                                 print('translated image ' + visual.material.texture)
                                             except IOError:
                                                 visual.material.texture = ""
@@ -596,15 +601,18 @@ def getVisual(link, node):
                 Material.namedMaterial[materialName] = visual.material
             if hasElement(material, 'texture'):
                 visual.material.texture = material.getElementsByTagName('texture')[0].getAttribute('filename')
-                if os.path.splitext(visual.material.texture)[1] == '.tiff' or os.path.splitext(visual.material.texture)[1] == '.tif':
+                if os.path.splitext(visual.material.texture)[1] == '.tiff' \
+                   or os.path.splitext(visual.material.texture)[1] == '.tif':
                     for dirname, dirnames, filenames in os.walk('.'):
                         for filename in filenames:
                             if filename == str(visual.material.texture.split('/')[-1]):
                                 print('try to translate image ' + filename)
                                 try:
                                     tifImage = Image.open(os.path.join(dirname, filename))
-                                    tifImage.save(os.path.splitext(os.path.join('./' + robotName + '_' + 'textures', filename))[0] + '.png')
-                                    visual.material.texture = robotName + '_' + 'textures/' + os.path.splitext(filename)[0] + '.png'
+                                    tifImage.save(os.path.splitext(os.path.join('./' + robotName + '_' + 'textures',
+                                                                                filename))[0] + '.png')
+                                    visual.material.texture = (robotName + '_' + 'textures/' +
+                                                               os.path.splitext(filename)[0] + '.png')
                                 except IOError:
                                     visual.material.texture = ""
                                     print('failed to open ' + os.path.join(dirname, filename))
@@ -663,13 +671,15 @@ def getCollision(link, node):
 
         geometryElement = collisionElement.getElementsByTagName('geometry')[0]
         if hasElement(geometryElement, 'box'):
-            collision.geometry.box.x = float(geometryElement.getElementsByTagName('box')[0].getAttribute('size').split()[0])
-            collision.geometry.box.y = float(geometryElement.getElementsByTagName('box')[0].getAttribute('size').split()[1])
-            collision.geometry.box.z = float(geometryElement.getElementsByTagName('box')[0].getAttribute('size').split()[2])
+            size = geometryElement.getElementsByTagName('box')[0].getAttribute('size').split()
+            collision.geometry.box.x = float(size[0])
+            collision.geometry.box.y = float(size[1])
+            collision.geometry.box.z = float(size[2])
             link.collision.append(collision)
         elif hasElement(geometryElement, 'cylinder'):
-            collision.geometry.cylinder.radius = float(geometryElement.getElementsByTagName('cylinder')[0].getAttribute('radius'))
-            collision.geometry.cylinder.length = float(geometryElement.getElementsByTagName('cylinder')[0].getAttribute('length'))
+            element = geometryElement.getElementsByTagName('cylinder')[0]
+            collision.geometry.cylinder.radius = float(element.getAttribute('radius'))
+            collision.geometry.cylinder.length = float(element.getAttribute('length'))
             link.collision.append(collision)
         elif hasElement(geometryElement, 'sphere'):
             collision.geometry.sphere.radius = float(geometryElement.getElementsByTagName('sphere')[0].getAttribute('radius'))
@@ -833,8 +843,10 @@ def parseGazeboElement(element, parentLink, linkList):
                         camera.width = int(imageElement.getElementsByTagName('width')[0].firstChild.nodeValue)
                     if hasElement(imageElement, 'height'):
                         camera.height = int(imageElement.getElementsByTagName('height')[0].firstChild.nodeValue)
-                    if hasElement(imageElement, 'format') and imageElement.getElementsByTagName('format')[0].firstChild.nodeValue != 'R8G8B8A8':
-                        print('Unsupported "%s" image format, using "R8G8B8A8" instead.' % str(imageElement.getElementsByTagName('format')[0].firstChild.nodeValue))
+                    if hasElement(imageElement, 'format') \
+                       and imageElement.getElementsByTagName('format')[0].firstChild.nodeValue != 'R8G8B8A8':
+                        print('Unsupported "%s" image format, using "R8G8B8A8" instead.' %
+                              str(imageElement.getElementsByTagName('format')[0].firstChild.nodeValue))
             if hasElement(sensorElement, 'noise'):
                 noiseElement = sensorElement.getElementsByTagName('noise')[0]
                 if hasElement(noiseElement, 'stddev'):
@@ -853,7 +865,8 @@ def parseGazeboElement(element, parentLink, linkList):
                     if hasElement(scanElement, 'horizontal'):
                         horizontalElement = scanElement.getElementsByTagName('horizontal')[0]
                         if hasElement(horizontalElement, 'samples'):
-                            lidar.horizontalResolution = int(float(horizontalElement.getElementsByTagName('samples')[0].firstChild.nodeValue))
+                            lidar.horizontalResolution = \
+                              int(float(horizontalElement.getElementsByTagName('samples')[0].firstChild.nodeValue))
                         if hasElement(horizontalElement, 'min_angle') and hasElement(horizontalElement, 'max_angle'):
                             minAngle = float(horizontalElement.getElementsByTagName('min_angle')[0].firstChild.nodeValue)
                             maxAngle = float(horizontalElement.getElementsByTagName('max_angle')[0].firstChild.nodeValue)
@@ -861,7 +874,8 @@ def parseGazeboElement(element, parentLink, linkList):
                     if hasElement(scanElement, 'vertical'):
                         horizontalElement = scanElement.getElementsByTagName('horizontal')[0]
                         if hasElement(horizontalElement, 'samples'):
-                            lidar.numberOfLayers = int(horizontalElement.getElementsByTagName('samples')[0].firstChild.nodeValue)
+                            lidar.numberOfLayers = \
+                              int(horizontalElement.getElementsByTagName('samples')[0].firstChild.nodeValue)
                         if hasElement(horizontalElement, 'min_angle') and hasElement(horizontalElement, 'max_angle'):
                             minAngle = float(horizontalElement.getElementsByTagName('min_angle')[0].firstChild.nodeValue)
                             maxAngle = float(horizontalElement.getElementsByTagName('max_angle')[0].firstChild.nodeValue)

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -675,8 +675,9 @@ def getVisual(link, node, path):
             visual.geometry.sphere.radius = float(geometryElement.getElementsByTagName('sphere')[0].getAttribute('radius'))
             link.visual.append(visual)
         elif hasElement(geometryElement, 'mesh'):
-            meshfile = os.path.normpath(os.path.join(path,
-                                                     geometryElement.getElementsByTagName('mesh')[0].getAttribute('filename')))
+            meshPath = geometryElement.getElementsByTagName('mesh')[0].getAttribute('filename')
+            if not os.path.isabs(meshPath):
+                meshfile = os.path.normpath(os.path.join(path, meshPath)
             # hack for gazebo mesh database
             if meshfile.count('package'):
                 idx0 = meshfile.find('package://')

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -679,9 +679,9 @@ def getVisual(link, node, path):
             visual.geometry.sphere.radius = float(geometryElement.getElementsByTagName('sphere')[0].getAttribute('radius'))
             link.visual.append(visual)
         elif hasElement(geometryElement, 'mesh'):
-            meshPath = geometryElement.getElementsByTagName('mesh')[0].getAttribute('filename')
-            if not os.path.isabs(meshPath):
-                meshfile = os.path.normpath(os.path.join(path, meshPath))
+            meshfile = geometryElement.getElementsByTagName('mesh')[0].getAttribute('filename')
+            if not os.path.isabs(meshfile):
+                meshfile = os.path.normpath(os.path.join(path, meshfile))
             # hack for gazebo mesh database
             if meshfile.count('package'):
                 idx0 = meshfile.find('package://')

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -681,7 +681,7 @@ def getVisual(link, node, path):
         elif hasElement(geometryElement, 'mesh'):
             meshPath = geometryElement.getElementsByTagName('mesh')[0].getAttribute('filename')
             if not os.path.isabs(meshPath):
-                meshfile = os.path.normpath(os.path.join(path, meshPath)
+                meshfile = os.path.normpath(os.path.join(path, meshPath))
             # hack for gazebo mesh database
             if meshfile.count('package'):
                 idx0 = meshfile.find('package://')

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -867,13 +867,9 @@ def getJoint(node):
 
 def isRootLink(link, childList):
     """Check if a link is root link."""
-    # return link in childList
-
     for child in childList:
         if link == child:
             return False
-
-    print(str([link]), " not found in ", str(childList))
     return True
 
 

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -422,7 +422,7 @@ def getOBJMesh(filename, node):
     with open(filename, 'r') as file:
         trimesh = node.geometry.trimesh
         for line in file:
-            (header, body) = line.split(maxsplit=1)
+            header, body = line.split(maxsplit=1)
             if header == '#':
                 continue
             elif header == 'f':  # face
@@ -448,16 +448,20 @@ def getOBJMesh(filename, node):
             elif header == 'o':  # object name, ignored
                 continue
             elif header == 'v':  # vertex
-                (x, y, z) = body.split()
+                x, y, z = body.split()
                 trimesh.coord.append([float(x), float(y), float(z)])
             elif header == 'vn':  # normals
-                (x, y, z) = body.split()
+                x, y, z = body.split()
                 trimesh.normal.append([float(x), float(y), float(z)])
             elif header == 'vp':  # parameters, ignored
                 continue
-            elif header == 'vt':  # texture coordinate, ignored
+            elif header == 'vt':  # texture coordinate
+                texCoord = body.split()
+                lenght = len(texCoord)
+                if length < 1:  # v argument is optional and defaults to 0
+                    texCoord.append('0')
+                trimesh.texCoord.append([float(texCoord[0]), float(texCoord[1])])
                 continue
-
     return node
 
 

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -246,7 +246,7 @@ def URDFBoundingObject(proto, link, level, boxCollision):
 
 
 def computeDefName(name):
-    """Compute a VRML compliant DEF name from an arbitrary string"""
+    """Compute a VRML compliant DEF name from an arbitrary string."""
     return name.replace(' ', '_').replace('.', '_')
 
 

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -61,8 +61,13 @@ def URDFLink(proto, link, level, parentList, childList, linkList, jointList, sen
         proto.write((level + 1) * indent + 'controller IS controller\n')
     else:
         proto.write((' ' if endpoint else level * indent) + 'Solid {\n')
-        proto.write((level + 1) * indent + 'translation %lf %lf %lf\n' % (jointPosition[0], jointPosition[1], jointPosition[2]))
-        proto.write((level + 1) * indent + 'rotation %lf %lf %lf %lf\n' % (jointRotation[0], jointRotation[1], jointRotation[2], jointRotation[3]))
+        proto.write((level + 1) * indent + 'translation %lf %lf %lf\n' % (jointPosition[0],
+                                                                          jointPosition[1],
+                                                                          jointPosition[2]))
+        proto.write((level + 1) * indent + 'rotation %lf %lf %lf %lf\n' % (jointRotation[0],
+                                                                           jointRotation[1],
+                                                                           jointRotation[2],
+                                                                           jointRotation[3]))
     if not dummy:  # dummy: case when link not defined but referenced (e.g. Atlas robot)
         # 1: export Shapes
         if link.visual:
@@ -98,11 +103,15 @@ def URDFLink(proto, link, level, parentList, childList, linkList, jointList, sen
         proto.write((level + 2) * indent + 'density -1\n')
         proto.write((level + 2) * indent + 'mass %lf\n' % link.inertia.mass)
         if link.inertia.ixx > 0.0 and link.inertia.iyy > 0.0 and link.inertia.izz > 0.0:
-            proto.write((level + 2) * indent + 'centerOfMass [ %lf %lf %lf ]\n' % (link.inertia.position[0], link.inertia.position[1], link.inertia.position[2]))
+            proto.write((level + 2) * indent + 'centerOfMass [ %lf %lf %lf ]\n' % (link.inertia.position[0],
+                                                                                   link.inertia.position[1],
+                                                                                   link.inertia.position[2]))
         proto.write((level + 1) * indent + '}\n')
 
         if link.inertia.rotation[-1] != 0.0:  # this should not happend
-            print('Warning: inertia of %s has a non-zero rotation [axis-angle] = "%lf %lf %lf %lf" but it will not be imported in proto!' % (link.name, link.inertia.rotation[0], link.inertia.rotation[1], link.inertia.rotation[2], link.inertia.rotation[3]))
+            print('Warning: inertia of %s has a non-zero rotation [axis-angle] = "%lf %lf %lf %lf" '
+                  'but it will not be imported in proto!' % (link.name, link.inertia.rotation[0], link.inertia.rotation[1],
+                                                             link.inertia.rotation[2], link.inertia.rotation[3]))
 
     proto.write(level * indent + '}\n')
 
@@ -122,8 +131,13 @@ def URDFBoundingObject(proto, link, level, boxCollision):
         initialIndent = boundingLevel * indent if hasGroup else ''
         if boundingObject.position != [0.0, 0.0, 0.0] or boundingObject.rotation[3] != 0.0:
             proto.write(initialIndent + 'Transform {\n')
-            proto.write((boundingLevel + 1) * indent + 'translation %lf %lf %lf\n' % (boundingObject.position[0], boundingObject.position[1], boundingObject.position[2]))
-            proto.write((boundingLevel + 1) * indent + 'rotation %lf %lf %lf %lf\n' % (boundingObject.rotation[0], boundingObject.rotation[1], boundingObject.rotation[2], boundingObject.rotation[3]))
+            proto.write((boundingLevel + 1) * indent + 'translation %lf %lf %lf\n' % (boundingObject.position[0],
+                                                                                      boundingObject.position[1],
+                                                                                      boundingObject.position[2]))
+            proto.write((boundingLevel + 1) * indent + 'rotation %lf %lf %lf %lf\n' % (boundingObject.rotation[0],
+                                                                                       boundingObject.rotation[1],
+                                                                                       boundingObject.rotation[2],
+                                                                                       boundingObject.rotation[3]))
             proto.write((boundingLevel + 1) * indent + 'children [\n')
             boundingLevel = boundingLevel + 2
             hasGroup = True
@@ -131,7 +145,9 @@ def URDFBoundingObject(proto, link, level, boxCollision):
 
         if boundingObject.geometry.box.x != 0:
             proto.write(initialIndent + 'Box {\n')
-            proto.write((boundingLevel + 1) * indent + ' size %lf %lf %lf\n' % (boundingObject.geometry.box.x, boundingObject.geometry.box.y, boundingObject.geometry.box.z))
+            proto.write((boundingLevel + 1) * indent + ' size %lf %lf %lf\n' % (boundingObject.geometry.box.x,
+                                                                                boundingObject.geometry.box.y,
+                                                                                boundingObject.geometry.box.z))
             proto.write(boundingLevel * indent + '}\n')
 
         elif boundingObject.geometry.cylinder.radius != 0 and boundingObject.geometry.cylinder.length != 0:
@@ -185,26 +201,31 @@ def URDFBoundingObject(proto, link, level, boxCollision):
                 proto.write(initialIndent + 'USE %s\n' % boundingObject.geometry.defName)
             else:
                 if boundingObject.geometry.name is not None:
-                    proto.write(initialIndent + 'DEF %s IndexedFaceSet {\n' % boundingObject.geometry.name)
-                    boundingObject.geometry.defName = boundingObject.geometry.name
+                    boundingObject.geometry.defName = defName(boundingObject.geometry.name)
+                    proto.write(initialIndent + 'DEF %s IndexedFaceSet {\n' % boundingObject.geometry.defName)
                 else:
                     proto.write(initialIndent + 'IndexedFaceSet {\n')
 
                 proto.write((boundingLevel + 1) * indent + 'coord Coordinate {\n')
                 proto.write((boundingLevel + 2) * indent + 'point [\n' + (boundingLevel + 3) * indent)
                 for value in boundingObject.geometry.trimesh.coord:
-                    proto.write('%lf %lf %lf, ' % (value[0] * boundingObject.geometry.scale[0], value[1] * boundingObject.geometry.scale[1], value[2] * boundingObject.geometry.scale[2]))
+                    proto.write('%lf %lf %lf, ' % (value[0] * boundingObject.geometry.scale[0],
+                                                   value[1] * boundingObject.geometry.scale[1],
+                                                   value[2] * boundingObject.geometry.scale[2]))
                 proto.write('\n' + (boundingLevel + 2) * indent + ']\n')
                 proto.write((boundingLevel + 1) * indent + '}\n')
 
                 proto.write((boundingLevel + 1) * indent + 'coordIndex [\n' + (boundingLevel + 2) * indent)
-                if isinstance(boundingObject.geometry.trimesh.coordIndex[0], np.ndarray) or type(boundingObject.geometry.trimesh.coordIndex[0]) == list:
+                if isinstance(boundingObject.geometry.trimesh.coordIndex[0], np.ndarray) \
+                   or type(boundingObject.geometry.trimesh.coordIndex[0]) == list:
                     for value in boundingObject.geometry.trimesh.coordIndex:
                         if len(value) == 3:
                             proto.write('%d %d %d -1 ' % (value[0], value[1], value[2]))
                 elif isinstance(boundingObject.geometry.trimesh.coordIndex[0], np.int32):
                     for i in range(len(boundingObject.geometry.trimesh.coordIndex) / 3):
-                        proto.write('%d %d %d -1 ' % (boundingObject.geometry.trimesh.coordIndex[3 * i + 0], boundingObject.geometry.trimesh.coordIndex[3 * i + 1], boundingObject.geometry.trimesh.coordIndex[3 * i + 2]))
+                        proto.write('%d %d %d -1 ' % (boundingObject.geometry.trimesh.coordIndex[3 * i + 0],
+                                                      boundingObject.geometry.trimesh.coordIndex[3 * i + 1],
+                                                      boundingObject.geometry.trimesh.coordIndex[3 * i + 2]))
                 else:
                     print('Unsupported "%s" coordinate type' % type(boundingObject.geometry.trimesh.coordIndex[0]))
                 proto.write('\n' + (boundingLevel + 1) * indent + ']\n')
@@ -224,6 +245,10 @@ def URDFBoundingObject(proto, link, level, boxCollision):
         proto.write(level * indent + '}\n')
 
 
+def defName(name):
+    return name.replace(' ', '_').replace('.', '_')
+
+
 def URDFShape(proto, link, level, normal=False):
     """Write a Shape."""
     indent = '  '
@@ -233,8 +258,13 @@ def URDFShape(proto, link, level, normal=False):
     for visualNode in link.visual:
         if visualNode.position != [0.0, 0.0, 0.0] or visualNode.rotation[3] != 0:
             proto.write(shapeLevel * indent + 'Transform {\n')
-            proto.write((shapeLevel + 1) * indent + 'translation %lf %lf %lf\n' % (visualNode.position[0], visualNode.position[1], visualNode.position[2]))
-            proto.write((shapeLevel + 1) * indent + 'rotation %lf %lf %lf %lf\n' % (visualNode.rotation[0], visualNode.rotation[1], visualNode.rotation[2], visualNode.rotation[3]))
+            proto.write((shapeLevel + 1) * indent + 'translation %lf %lf %lf\n' % (visualNode.position[0],
+                                                                                   visualNode.position[1],
+                                                                                   visualNode.position[2]))
+            proto.write((shapeLevel + 1) * indent + 'rotation %lf %lf %lf %lf\n' % (visualNode.rotation[0],
+                                                                                    visualNode.rotation[1],
+                                                                                    visualNode.rotation[2],
+                                                                                    visualNode.rotation[3]))
             proto.write((shapeLevel + 1) * indent + 'children [\n')
             shapeLevel += 2
             transform = True
@@ -244,21 +274,27 @@ def URDFShape(proto, link, level, normal=False):
             proto.write((shapeLevel + 1) * indent + 'appearance USE %s\n' % visualNode.material.defName)
         else:
             if visualNode.material.name is not None:
-                proto.write((shapeLevel + 1) * indent + 'appearance DEF %s PBRAppearance {\n' % visualNode.material.name)
-                visualNode.material.defName = visualNode.material.name
+                visualNode.material.defName = defName(visualNode.material.name)
+                proto.write((shapeLevel + 1) * indent + 'appearance DEF %s PBRAppearance {\n' % visualNode.material.defName)
             else:
                 proto.write((shapeLevel + 1) * indent + 'appearance PBRAppearance {\n')
             ambientColor = RGBA2RGB(visualNode.material.ambient)
             diffuseColor = RGBA2RGB(visualNode.material.diffuse, RGB_background=ambientColor)
             emissiveColor = RGBA2RGB(visualNode.material.emission, RGB_background=ambientColor)
-            roughness = 1.0 - visualNode.material.specular.alpha * (visualNode.material.specular.red + visualNode.material.specular.green + visualNode.material.specular.blue) / 3.0
+            roughness = 1.0 - visualNode.material.specular.alpha * (visualNode.material.specular.red +
+                                                                    visualNode.material.specular.green +
+                                                                    visualNode.material.specular.blue) / 3.0
             if visualNode.material.shininess:
                 roughness *= (1.0 - 0.5 * visualNode.material.shininess)
-            proto.write((shapeLevel + 2) * indent + 'baseColor %lf %lf %lf\n' % (diffuseColor.red, diffuseColor.green, diffuseColor.blue))
+            proto.write((shapeLevel + 2) * indent + 'baseColor %lf %lf %lf\n' % (diffuseColor.red,
+                                                                                 diffuseColor.green,
+                                                                                 diffuseColor.blue))
             proto.write((shapeLevel + 2) * indent + 'transparency %lf\n' % (1.0 - visualNode.material.diffuse.alpha))
             proto.write((shapeLevel + 2) * indent + 'roughness %lf\n' % roughness)
             proto.write((shapeLevel + 2) * indent + 'metalness 0\n')
-            proto.write((shapeLevel + 2) * indent + 'emissiveColor %lf %lf %lf\n' % (emissiveColor.red, emissiveColor.green, emissiveColor.blue))
+            proto.write((shapeLevel + 2) * indent + 'emissiveColor %lf %lf %lf\n' % (emissiveColor.red,
+                                                                                     emissiveColor.green,
+                                                                                     emissiveColor.blue))
             if visualNode.material.texture != "":
                 proto.write((shapeLevel + 2) * indent + 'baseColorMap ImageTexture {\n')
                 proto.write((shapeLevel + 3) * indent + 'url [ "' + visualNode.material.texture + '" ]\n')
@@ -289,25 +325,30 @@ def URDFShape(proto, link, level, normal=False):
                 proto.write((shapeLevel + 1) * indent + 'geometry USE %s\n' % visualNode.geometry.defName)
             else:
                 if visualNode.geometry.name is not None:
-                    proto.write((shapeLevel + 1) * indent + 'geometry DEF %s IndexedFaceSet {\n' % visualNode.geometry.name)
-                    visualNode.geometry.defName = visualNode.geometry.name
+                    visualNode.geometry.defName = defName(visualNode.geometry.name)
+                    proto.write((shapeLevel + 1) * indent + 'geometry DEF %s IndexedFaceSet {\n' % visualNode.geometry.defName)
                 else:
                     proto.write((shapeLevel + 1) * indent + 'geometry IndexedFaceSet {\n')
                 proto.write((shapeLevel + 2) * indent + 'coord Coordinate {\n')
                 proto.write((shapeLevel + 3) * indent + 'point [\n' + (shapeLevel + 4) * indent)
                 for value in visualNode.geometry.trimesh.coord:
-                    proto.write('%lf %lf %lf, ' % (value[0] * visualNode.geometry.scale[0], value[1] * visualNode.geometry.scale[1], value[2] * visualNode.geometry.scale[2]))
+                    proto.write('%lf %lf %lf, ' % (value[0] * visualNode.geometry.scale[0],
+                                                   value[1] * visualNode.geometry.scale[1],
+                                                   value[2] * visualNode.geometry.scale[2]))
                 proto.write('\n' + (shapeLevel + 3) * indent + ']\n')
                 proto.write((shapeLevel + 2) * indent + '}\n')
 
                 proto.write((shapeLevel + 2) * indent + 'coordIndex [\n' + (shapeLevel + 3) * indent)
-                if isinstance(visualNode.geometry.trimesh.coordIndex[0], np.ndarray) or type(visualNode.geometry.trimesh.coordIndex[0]) == list:
+                if isinstance(visualNode.geometry.trimesh.coordIndex[0], np.ndarray) \
+                   or type(visualNode.geometry.trimesh.coordIndex[0]) == list:
                     for value in visualNode.geometry.trimesh.coordIndex:
                         if len(value) == 3:
                             proto.write('%d %d %d -1 ' % (value[0], value[1], value[2]))
                 elif isinstance(visualNode.geometry.trimesh.coordIndex[0], np.int32):
                     for i in range(int(len(visualNode.geometry.trimesh.coordIndex) / 3)):
-                        proto.write('%d %d %d -1 ' % (visualNode.geometry.trimesh.coordIndex[3 * i + 0], visualNode.geometry.trimesh.coordIndex[3 * i + 1], visualNode.geometry.trimesh.coordIndex[3 * i + 2]))
+                        proto.write('%d %d %d -1 ' % (visualNode.geometry.trimesh.coordIndex[3 * i + 0],
+                                                      visualNode.geometry.trimesh.coordIndex[3 * i + 1],
+                                                      visualNode.geometry.trimesh.coordIndex[3 * i + 2]))
                 else:
                     print('Unsupported "%s" coordinate type' % type(visualNode.geometry.trimesh.coordIndex[0]))
                 proto.write('\n' + (shapeLevel + 2) * indent + ']\n')
@@ -321,13 +362,16 @@ def URDFShape(proto, link, level, normal=False):
                     proto.write((shapeLevel + 2) * indent + '}\n')
 
                     proto.write((shapeLevel + 2) * indent + 'normalIndex [\n' + (shapeLevel + 3) * indent)
-                    if isinstance(visualNode.geometry.trimesh.normalIndex[0], np.ndarray) or type(visualNode.geometry.trimesh.normalIndex[0]) == list:
-                        for value in visualNode.geometry.trimesh.normalIndex != 0:
+                    if isinstance(visualNode.geometry.trimesh.normalIndex[0], np.ndarray) \
+                       or type(visualNode.geometry.trimesh.normalIndex[0]) == list:
+                        for value in visualNode.geometry.trimesh.normalIndex:
                             if len(value) == 3:
                                 proto.write('%d %d %d -1 ' % (value[0], value[1], value[2]))
                     elif isinstance(visualNode.geometry.trimesh.normalIndex[0], np.int32):
                         for i in range(len(visualNode.geometry.trimesh.normalIndex) / 3):
-                            proto.write('%d %d %d -1 ' % (visualNode.geometry.trimesh.normalIndex[3 * i + 0], visualNode.geometry.trimesh.normalIndex[3 * i + 1], visualNode.geometry.trimesh.normalIndex[3 * i + 2]))
+                            proto.write('%d %d %d -1 ' % (visualNode.geometry.trimesh.normalIndex[3 * i + 0],
+                                                          visualNode.geometry.trimesh.normalIndex[3 * i + 1],
+                                                          visualNode.geometry.trimesh.normalIndex[3 * i + 2]))
                     else:
                         print('Unsupported "%s" normal type' % type(visualNode.geometry.trimesh.normalIndex[0]))
                     proto.write('\n' + (shapeLevel + 2) * indent + ']\n')
@@ -341,13 +385,16 @@ def URDFShape(proto, link, level, normal=False):
                     proto.write((shapeLevel + 2) * indent + '}\n')
 
                     proto.write((shapeLevel + 2) * indent + 'texCoordIndex [\n' + (shapeLevel + 3) * indent)
-                    if isinstance(visualNode.geometry.trimesh.texCoordIndex[0], np.ndarray) or type(visualNode.geometry.trimesh.texCoordIndex[0]) == list:
+                    if isinstance(visualNode.geometry.trimesh.texCoordIndex[0], np.ndarray) \
+                       or type(visualNode.geometry.trimesh.texCoordIndex[0]) == list:
                         for value in visualNode.geometry.trimesh.texCoordIndex:
                             if len(value) == 3:
                                 proto.write('%d %d %d -1 ' % (value[0], value[1], value[2]))
                     elif isinstance(visualNode.geometry.trimesh.texCoordIndex[0], np.int32):
                         for i in range(len(visualNode.geometry.trimesh.texCoordIndex) / 3):
-                            proto.write('%d %d %d -1 ' % (visualNode.geometry.trimesh.texCoordIndex[3 * i + 0], visualNode.geometry.trimesh.texCoordIndex[3 * i + 1], visualNode.geometry.trimesh.texCoordIndex[3 * i + 2]))
+                            proto.write('%d %d %d -1 ' % (visualNode.geometry.trimesh.texCoordIndex[3 * i + 0],
+                                                          visualNode.geometry.trimesh.texCoordIndex[3 * i + 1],
+                                                          visualNode.geometry.trimesh.texCoordIndex[3 * i + 2]))
                     else:
                         print('Unsupported "%s" coordinate type' % type(visualNode.geometry.trimesh.texCoordIndex[0]))
                     proto.write('\n' + (shapeLevel + 2) * indent + ']\n')

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -201,7 +201,7 @@ def URDFBoundingObject(proto, link, level, boxCollision):
                 proto.write(initialIndent + 'USE %s\n' % boundingObject.geometry.defName)
             else:
                 if boundingObject.geometry.name is not None:
-                    boundingObject.geometry.defName = defName(boundingObject.geometry.name)
+                    boundingObject.geometry.defName = computeDefName(boundingObject.geometry.name)
                     proto.write(initialIndent + 'DEF %s IndexedFaceSet {\n' % boundingObject.geometry.defName)
                 else:
                     proto.write(initialIndent + 'IndexedFaceSet {\n')
@@ -245,7 +245,8 @@ def URDFBoundingObject(proto, link, level, boxCollision):
         proto.write(level * indent + '}\n')
 
 
-def defName(name):
+def computeDefName(name):
+    """Compute a VRML compliant DEF name from an arbitrary string"""
     return name.replace(' ', '_').replace('.', '_')
 
 
@@ -274,7 +275,7 @@ def URDFShape(proto, link, level, normal=False):
             proto.write((shapeLevel + 1) * indent + 'appearance USE %s\n' % visualNode.material.defName)
         else:
             if visualNode.material.name is not None:
-                visualNode.material.defName = defName(visualNode.material.name)
+                visualNode.material.defName = computeDefName(visualNode.material.name)
                 proto.write((shapeLevel + 1) * indent + 'appearance DEF %s PBRAppearance {\n' % visualNode.material.defName)
             else:
                 proto.write((shapeLevel + 1) * indent + 'appearance PBRAppearance {\n')
@@ -325,7 +326,7 @@ def URDFShape(proto, link, level, normal=False):
                 proto.write((shapeLevel + 1) * indent + 'geometry USE %s\n' % visualNode.geometry.defName)
             else:
                 if visualNode.geometry.name is not None:
-                    visualNode.geometry.defName = defName(visualNode.geometry.name)
+                    visualNode.geometry.defName = computeDefName(visualNode.geometry.name)
                     proto.write((shapeLevel + 1) * indent + 'geometry DEF %s IndexedFaceSet {\n' % visualNode.geometry.defName)
                 else:
                     proto.write((shapeLevel + 1) * indent + 'geometry IndexedFaceSet {\n')


### PR DESCRIPTION
This PR fixes the import of a URDF model created with [phobos](https://github.com/dfki-ric/phobos) and OBJ meshes.

In addition to OBJ support, this PR:
- Fixes the computation of the root link which was wrong.
- Fixes the import of the normal per vertex which was broken.
- Fixes a line length of python code that was exceeding our coding style limit (128 chars).
- Fixes a bug preventing the script to find the mesh files if not run from the URDF directory.
- Fixes the generation of DEF names which may contain spaces or dot characters (which are illegal for a VRML DEF name).