### PR TITLE
name fix/add, material fix

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -7,25 +7,27 @@ import optparse
 from urdf2webots.importer import convert2urdf
 
 
-optParser = optparse.OptionParser(usage='usage: %prog --input=my_robot.urdf [options]')
-optParser.add_option('--input', dest='inFile', default='', help='Specifies the urdf file to convert.')
-optParser.add_option('--output', dest='outFile', default='', help='Specifies the name of the resulting PROTO file.')
-optParser.add_option('--normal', dest='normal', action='store_true', default=False,
-                     help='If set, the normals are exported if present in the URDF definition.')
-optParser.add_option('--box-collision', dest='boxCollision', action='store_true', default=False,
-                     help='If set, the bounding objects are approximated using boxes.')
-optParser.add_option('--disable-mesh-optimization', dest='disableMeshOptimization', action='store_true', default=False,
-                     help='If set, the duplicated vertices are not removed from the meshes (this can speed up a lot the '
-                     'conversion).')
-optParser.add_option('--multi-file', dest='enableMultiFile', action='store_true', default=False,
-                     help='If set, the mesh files are exported as separated PROTO files')
-optParser.add_option('--static-base', dest='staticBase', action='store_true', default=False,
-                     help='If set, the base link will have the option to be static (disable physics)')
-optParser.add_option('--tool-slot', dest='toolSlot', default=None,
-                     help='Specify the link that you want to add a tool slot to (exact link name from urdf)')
-optParser.add_option('--rotation', dest='initRotation', default='0 1 0 0',
-                     help='Set the rotation field of your PROTO file.)')
-options, args = optParser.parse_args()
+if __name__ == '__main__':
+    optParser = optparse.OptionParser(usage='usage: %prog --input=my_robot.urdf [options]')
+    optParser.add_option('--input', dest='inFile', default='', help='Specifies the urdf file to convert.')
+    optParser.add_option('--nane', dest='robotName', default=None, help='The exact name of the webots model and filename.')
+    optParser.add_option('--output', dest='outPath', default='', help='Specifies where the .proto file will be generated. Path has to end with "/"')
+    optParser.add_option('--normal', dest='normal', action='store_true', default=False,
+                         help='If set, the normals are exported if present in the URDF definition.')
+    optParser.add_option('--box-collision', dest='boxCollision', action='store_true', default=False,
+                         help='If set, the bounding objects are approximated using boxes.')
+    optParser.add_option('--disable-mesh-optimization', dest='disableMeshOptimization', action='store_true', default=False,
+                         help='If set, the duplicated vertices are not removed from the meshes (this can speed up a lot the '
+                         'conversion).')
+    optParser.add_option('--multi-file', dest='enableMultiFile', action='store_true', default=False,
+                         help='If set, the mesh files are exported as separated PROTO files')
+    optParser.add_option('--static-base', dest='staticBase', action='store_true', default=False,
+                         help='If set, the base link will have the option to be static (disable physics)')
+    optParser.add_option('--tool-slot', dest='toolSlot', default=None,
+                         help='Specify the link that you want to add a tool slot too (exact link name from urdf)')
+    optParser.add_option('--rotation', dest='initRotation', default='0 1 0 0',
+                         help='Set the rotation field of your PROTO file.')
+    options, args = optParser.parse_args()
 
-convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization,
-             options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation)
+    convert2urdf(options.inFile, options.robotName, options.outPath, options.normal, options.boxCollision, options.disableMeshOptimization,
+                 options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -46,7 +46,7 @@ def mkdirSafe(directory):
             print('Directory "' + directory + '" already exists!')
 
 
-def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
+def convert2urdf(inFile, robotName=None, outPath=None, normal=False, boxCollision=False,
                  disableMeshOptimization=False, enableMultiFile=False, staticBase=False, toolSlot=None, initRotation='0 1 0 0'):
     if not os.path.exists(inFile):
         sys.exit('Input file "%s" does not exists.' % inFile)
@@ -86,9 +86,10 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
 
         for child in domFile.childNodes:
             if child.localName == 'robot':
-                robotName = convertLUtoUN(urdf2webots.parserURDF.getRobotName(child))  # capitalize
+                if not robotName:
+                    robotName = convertLUtoUN(urdf2webots.parserURDF.getRobotName(child))  # capitalize
                 urdf2webots.writeProto.robotNameMain = robotName
-                outputFile = outFile if outFile else robotName + '.proto'
+                outputFile = outPath + robotName + '.proto'
 
                 urdf2webots.parserURDF.robotName = robotName  # pass robotName
                 mkdirSafe(outputFile.replace('.proto', '') + '_textures')  # make a dir called 'x_textures'
@@ -172,7 +173,8 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
 if __name__ == '__main__':
     optParser = optparse.OptionParser(usage='usage: %prog --input=my_robot.urdf [options]')
     optParser.add_option('--input', dest='inFile', default='', help='Specifies the urdf file to convert.')
-    optParser.add_option('--output', dest='outFile', default='', help='Specifies the name of the resulting PROTO file.')
+    optParser.add_option('--nane', dest='robotName', default=None, help='The exact name of the webots model and filename.')
+    optParser.add_option('--output', dest='outPath', default='', help='Specifies where the .proto file will be generated. Path has to end with "/"')
     optParser.add_option('--normal', dest='normal', action='store_true', default=False,
                          help='If set, the normals are exported if present in the URDF definition.')
     optParser.add_option('--box-collision', dest='boxCollision', action='store_true', default=False,
@@ -190,5 +192,5 @@ if __name__ == '__main__':
                          help='Set the rotation field of your PROTO file.')
     options, args = optParser.parse_args()
 
-    convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization,
+    convert2urdf(options.inFile, options.robotName, options.outPath, options.normal, options.boxCollision, options.disableMeshOptimization,
                  options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation)

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -638,7 +638,10 @@ def getVisual(link, node, path):
                 visual.material.diffuse.blue = float(colorElement[2])
                 visual.material.diffuse.alpha = float(colorElement[3])
                 if material.hasAttribute('name'):
-                    visual.material.name = material.getAttribute('name')
+                    if material.getAttribute('name') != '':
+                        visual.material.name = material.getAttribute('name')
+                    else:
+                        visual.material.name = node.getAttribute('name') + '_material'    
                     Material.namedMaterial[visual.material.name] = visual.material
             elif material.firstChild and material.firstChild.nodeValue in materials:
                 materialName = material.firstChild.nodeValue

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -57,6 +57,7 @@ def declaration(proto, robotName, initRotation):
     proto.write('PROTO ' + robotName + ' [\n')
     proto.write('  field  SFVec3f     translation     0 0 0\n')
     proto.write('  field  SFRotation  rotation        ' + initRotation + '\n')
+    proto.write('  field  SFString    name      ' + robotName + '  # Name of robot base node. Has to be unique when using multiple robots.\n')
     proto.write('  field  SFString    controller      "void" # Is `Robot.controller`.\n')
     proto.write('  field  MFString    controllerArgs  []     # Is `Robot.controllerArgs`.\n')
     proto.write('  field  SFString    customData      ""     # Is `Robot.customData`.\n')
@@ -121,16 +122,27 @@ def URDFLink(proto, link, level, parentList, childList, linkList, jointList, sen
                           linkList, jointList, sensorList, boxCollision, normal)
         # 4: export ToolSlot if specified
         if link.name == toolSlot:
+            # add dummy physics and bounding object, so tools don't fall off
+            if link.inertia.mass is None:
+                proto.write((level + 1) * indent + 'physics Physics {\n')    
+                proto.write((level + 2) * indent + 'centerOfMass [ 0 0 0 ]\n')
+                proto.write((level + 1) * indent + '}\n')
+
+                proto.write((level + 1) * indent + 'boundingObject Box {\n')    
+                proto.write((level + 2) * indent + 'size 0.01 0.01 0.01\n')
+                proto.write((level + 1) * indent + '}\n')
             if not haveChild:
                 haveChild = True
                 proto.write((level + 1) * indent + 'children [\n')
             proto.write((level + 2) * indent + 'Group {\n')
             proto.write((level + 3) * indent + 'children IS toolSlot\n')
-            proto.write((level + 2) * indent + '}\n')
+            proto.write((level + 2) * indent + '}\n')            
+
 
         if haveChild:
             proto.write((level + 1) * indent + ']\n')
-
+        if level == 1:
+            link.name = robotNameMain
         proto.write((level + 1) * indent + 'name "' + link.name + '"\n')
 
         if link.collision:


### PR DESCRIPTION
This PR includes several fixes and changes:
- name field, which specifies the name of the base node. default gets set to the robot name
- fixed a bug, where materials were not parsed, when they had the name="" (mirobot convertion as example)
- fixed the toolSlot generation. When adding a gripper, it fell off. added a physics and bounding object node
- specifying a output file, broke the conversion, as the filename and proto name has to be identical. I split it up into outputPath and name, The name get's take for both, the file AND the protos definition
