### PR TITLE
added --insert-mesh --mesh-transform option to reduce file size of proto files. It also decreases loading times in webots significantly.

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -14,6 +14,11 @@ if __name__ == '__main__':
                          ' The filename minus the .proto extension will be the robot name.')
     optParser.add_option('--normal', dest='normal', action='store_true', default=False,
                          help='If set, the normals are exported if present in the URDF definition.')
+    optParser.add_option('--insert-mesh', dest='insertMesh', action='store_true', default=False,
+                         help='If set, the mesh is exported in the proto file. Otherwise the filepath to the meshes are exported.')
+    optParser.add_option('--mesh-transform', dest='meshTransform', default='',
+                         help='Set the transformation composed by a translation and euler axis representation required to visualize meshed loaded from files correctly.'
+                         'Usage: --mesh-transform="x, y, z, r, p, y, angle')
     optParser.add_option('--box-collision', dest='boxCollision', action='store_true', default=False,
                          help='If set, the bounding objects are approximated using boxes.')
     optParser.add_option('--disable-mesh-optimization', dest='disableMeshOptimization', action='store_true', default=False,
@@ -36,5 +41,5 @@ if __name__ == '__main__':
                          help='If set, urdf joint names are also used as DEF names as well as joint names.')
     options, args = optParser.parse_args()
 
-    convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization,
+    convert2urdf(options.inFile, options.outFile, options.normal, options.insertMesh, options.meshTransform, options.boxCollision, options.disableMeshOptimization,
                  options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos, options.linkToDef, options.jointToDef)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -46,7 +46,7 @@ def mkdirSafe(directory):
             print('Directory "' + directory + '" already exists!')
 
 
-def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
+def convert2urdf(inFile, outFile=None, normal=False, insertMesh=False, meshTransform='', boxCollision=False,
                  disableMeshOptimization=False, enableMultiFile=False, staticBase=False, toolSlot=None,
                  initRotation='0 1 0 0', initPos=None, linkToDef=False, jointToDef=False):
     if not os.path.exists(inFile):
@@ -183,7 +183,8 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
 
                 urdf2webots.writeProto.declaration(protoFile, robotName, initRotation)
                 urdf2webots.writeProto.URDFLink(protoFile, rootLink, 1, parentList, childList, linkList, jointList,
-                                                sensorList, boxCollision=boxCollision, normal=normal, robot=True)
+                                                sensorList, boxCollision=boxCollision, normal=normal,
+                                                insertMesh=insertMesh, meshTransform=meshTransform, robot=True)
                 protoFile.write('}\n')
                 protoFile.close()
                 return
@@ -197,6 +198,11 @@ if __name__ == '__main__':
                          'of the resulting PROTO file. The filename minus the .proto extension will be the robot name.')
     optParser.add_option('--normal', dest='normal', action='store_true', default=False,
                          help='If set, the normals are exported if present in the URDF definition.')
+    optParser.add_option('--insert-mesh', dest='insertMesh', action='store_true', default=False,
+                         help='If set, the mesh is exported in the proto file. Otherwise the filepath to the meshes are exported.')
+    optParser.add_option('--mesh-transform', dest='meshTransform', default='',
+                         help='Set the transformation composed by a translation and euler axis representation required to visualize meshed loaded from files correctly.'
+                         'Usage: --mesh-transform="x, y, z, r, p, y, angle')
     optParser.add_option('--box-collision', dest='boxCollision', action='store_true', default=False,
                          help='If set, the bounding objects are approximated using boxes.')
     optParser.add_option('--disable-mesh-optimization', dest='disableMeshOptimization', action='store_true', default=False,
@@ -219,5 +225,5 @@ if __name__ == '__main__':
     optParser.add_option('--joint-to-def', dest='jointToDef', action='store_true', default=False,
                          help='If set, urdf joint names are also used as DEF names as well as joint names.')
     options, args = optParser.parse_args()
-    convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization,
+    convert2urdf(options.inFile, options.outFile, options.normal, options.insertMesh, options.meshTransform, options.boxCollision, options.disableMeshOptimization,
                  options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos, options.linkToDef, options.jointToDef)

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -98,6 +98,7 @@ class Geometry():
         self.cylinder = Cylinder()
         self.sphere = Sphere()
         self.trimesh = Trimesh()
+        self.trimeshFile = ""
         self.scale = [1.0, 1.0, 1.0]
         self.name = None
         self.defName = None
@@ -446,6 +447,7 @@ def getSTLMesh(filename, node):
     b = struct.unpack("<3f", stlFile.read(12))
     c = struct.unpack("<3f", stlFile.read(12))
     struct.unpack("H", stlFile.read(2))
+    node.geometry.trimeshFile = filename
     trimesh = node.geometry.trimesh
     trimesh.coord.append(a)
     trimesh.coord.append(b)
@@ -513,6 +515,7 @@ def getOBJMesh(filename, node, link):
                 collision.geometry.scale = node.geometry.scale
                 extSring = '_%d' % (counter) if counter != 0 else ''
                 collision.geometry.name = '%s%s' % (os.path.splitext(os.path.basename(filename))[0], extSring)
+                collision.geometry.trimeshFile = filename
                 counter += 1
             elif header == 'f':  # face
                 vertices = body.split()
@@ -571,6 +574,7 @@ def getColladaMesh(filename, node, link):
                 index += 1
                 visual.position = node.position
                 visual.rotation = node.rotation
+                visual.geometry.trimeshFile = filename
                 visual.material.diffuse.red = node.material.diffuse.red
                 visual.material.diffuse.green = node.material.diffuse.green
                 visual.material.diffuse.blue = node.material.diffuse.blue
@@ -646,6 +650,7 @@ def getColladaMesh(filename, node, link):
                 collision = Collision()
                 collision.position = node.position
                 collision.rotation = node.rotation
+                collision.geometry.trimeshFile = filename
                 collision.geometry.scale = node.geometry.scale
                 for value in data.vertex:
                     collision.geometry.trimesh.coord.append(numpy.array(value))

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -346,7 +346,7 @@ def URDFVisual(proto, visualNode, level, normal=False, insertMesh=False, meshTra
 
     if useMeshfile:
         transform = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
-        if meshTransform:
+        if meshTransform and os.path.splitext(visualNode.geometry.trimeshFile)[1].lower() == '.dae':
             transform = meshTransform.split()
         scale = visualNode.geometry.scale
         proto.write(shapeLevel * indent + 'Transform {\n')

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -344,11 +344,15 @@ def URDFVisual(proto, visualNode, level, normal=False, insertMesh=False, meshTra
 
     useMeshfile = not insertMesh and visualNode.geometry.trimeshFile
 
-    if useMeshfile and meshTransform:
-        transform = meshTransform.split()
+    if useMeshfile:
+        transform = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+        if meshTransform:
+            transform = meshTransform.split()
+        scale = visualNode.geometry.scale
         proto.write(shapeLevel * indent + 'Transform {\n')
         proto.write((shapeLevel + 1) * indent + 'translation %s %s %s\n' % (transform[0], transform[1], transform[2]))
         proto.write((shapeLevel + 1) * indent + 'rotation %s %s %s %s\n' % (transform[3], transform[4], transform[5], transform[6]))
+        proto.write((shapeLevel + 1) * indent + 'scale %s %s %s\n' % (scale[0], scale[1], scale[2]))
         proto.write((shapeLevel + 1) * indent + 'children [\n')
         shapeLevel = shapeLevel + 2
 
@@ -505,7 +509,7 @@ def URDFVisual(proto, visualNode, level, normal=False, insertMesh=False, meshTra
 
     proto.write(shapeLevel * indent + '}\n')
 
-    if useMeshfile and meshTransform:
+    if useMeshfile:
         shapeLevel = shapeLevel - 2
         proto.write((shapeLevel + 1) * indent + ']\n')
         proto.write(shapeLevel * indent + '}\n')


### PR DESCRIPTION
Please note that this is in an experimental state. It should provide a good starting point to officially and cleanly support this new feature.

Known Issues/Todos:
- STL and .obj import isn't tested yet
- Handling of collada files is tricky as they can consist of multiple parts stored in a single file. In general, this seems not to be well reflected in the urdf2webots importer. This patch prevents already multiple includes of the same mesh file when using the "--insert-mesh" option. However, in general, this is an open issue for all other cases, e.g. generating bounding box approximation results in heavily duplicated collision boxes in the protos file.
- Using collada files, an additional transform seems to be required. I'm not sure why this happens, but it seems that webots is not considering the collada coordinate system when loading a collada mesh from a file?
- Webots seems not to load subparts in the collada file correctly. It uses only the mesh, but not the stored appearance individually set for each part. Using the provided feature may lead to wrongly textured/colored meshes in favor of greatly reduced loading times.

Feel free to modify the code! :-)

Best regards