### PR TITLE
add dummy physics for imu sensor to make gyro work

### DIFF
--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -2,7 +2,7 @@
 
 import math
 import numpy as np
-
+from urdf2webots.parserURDF import IMU
 from urdf2webots.math_utils import rotateVector, matrixFromRotation, multiplyMatrix, rotationFromMatrix
 
 toolSlot = None
@@ -112,6 +112,13 @@ def URDFLink(proto, link, level, parentList, childList, linkList, jointList, sen
         # 2: export Sensors
         for sensor in sensorList:
             if sensor.parentLink == link.name:
+                # add dummy physics for imu sensor if there is none since gyro requires it
+                if type(sensor) == IMU and link.inertia.mass is None:
+                    proto.write((level + 1) * indent + 'physics Physics {\n')
+                    proto.write((level + 1) * indent + '}\n')
+                    proto.write((level + 1) * indent + 'boundingObject Box {\n')
+                    proto.write((level + 1) * indent + 'size 0.01 0.01 0.01\n')
+                    proto.write((level + 1) * indent + '}\n')
                 if not haveChild:
                     haveChild = True
                     proto.write((level + 1) * indent + 'children [\n')


### PR DESCRIPTION
The gyro needs to be child to a Node with a a Physics element. Otherwise the following warning will pop up:
`WARNING: DEF Robot <robotname> (PROTO) > HingeJoint > Solid > HingeJoint > Solid > Solid > Gyro: this node or its parents requires a 'physics' field to be functional.`

In URDFs there is often an extra frame for an IMU which is attached by a fixed joint to the actual link the imu is attached to.

This PR adds a dummy physics node to the link holding the imu similar to the dummy physics added so tools don't fall off here: https://github.com/cyberbotics/urdf2webots/blob/aa6706adfc5c8039089aca0a330b54036d5386d4/urdf2webots/writeProto.py#L135