### PR TITLE
touch sensor for gazebo f3d plugins

### DIFF
--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -218,7 +218,7 @@ class Link():
         self.inertia = Inertia()
         self.visual = []
         self.collision = []
-        self.touchSensor = None
+        self.forceSensor = False
 
 
 class Joint():
@@ -345,18 +345,6 @@ class Lidar():
         if self.resolution:
             file.write(indentationLevel * indent + '  resolution %lf\n' % self.resolution)
         file.write(indentationLevel * indent + '}\n')
-
-
-class TouchSensor:
-    """ Defines a Touch sensor."""
-    def __init__(self):
-        self.type = None
-
-    def export(self, file, indentationLevel):
-        """Export the touch sensor."""
-        indent = '  '
-        if self.type:
-            file.write(indentationLevel * indent + 'type "%s"\n' % self.type)
 
 
 def colorVector2Instance(cv, alpha_last=True):
@@ -950,17 +938,12 @@ def parseGazeboElement(element, parentLink, linkList):
                 imu.gaussianNoise = float(plugin.getElementsByTagName('gaussianNoise')[0].firstChild.nodeValue)
             IMU.list.append(imu)
         elif plugin.hasAttribute('filename') and plugin.getAttribute('filename').startswith('libgazebo_ros_f3d'):
-            touchSensor = TouchSensor()
-            touchSensor.type = "force-3d"
             if hasElement(plugin, "bodyName"):
-                touchSensorParent = None
                 name = plugin.getElementsByTagName('bodyName')[0].firstChild.nodeValue
                 for link in linkList:
                     if link.name == name:
-                        touchSensorParent = link
+                        link.forceSensor = True
                         break
-                if touchSensorParent:
-                    touchSensorParent.touchSensor = touchSensor
     for sensorElement in element.getElementsByTagName('sensor'):
         sensorElement = element.getElementsByTagName('sensor')[0]
         if sensorElement.getAttribute('type') == 'camera':

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -218,6 +218,7 @@ class Link():
         self.inertia = Inertia()
         self.visual = []
         self.collision = []
+        self.touchSensor = None
 
 
 class Joint():
@@ -344,6 +345,18 @@ class Lidar():
         if self.resolution:
             file.write(indentationLevel * indent + '  resolution %lf\n' % self.resolution)
         file.write(indentationLevel * indent + '}\n')
+
+
+class TouchSensor:
+    """ Defines a Touch sensor."""
+    def __init__(self):
+        self.type = None
+
+    def export(self, file, indentationLevel):
+        """Export the touch sensor."""
+        indent = '  '
+        if self.type:
+            file.write(indentationLevel * indent + '  type "%s"\n' % self.type)
 
 
 def colorVector2Instance(cv, alpha_last=True):
@@ -936,6 +949,18 @@ def parseGazeboElement(element, parentLink, linkList):
             if hasElement(plugin, 'gaussianNoise'):
                 imu.gaussianNoise = float(plugin.getElementsByTagName('gaussianNoise')[0].firstChild.nodeValue)
             IMU.list.append(imu)
+        elif plugin.hasAttribute('filename') and plugin.getAttribute('filename').startswith('libgazebo_ros_f3d'):
+            touchSensor = TouchSensor()
+            touchSensor.type = "force-3d"
+            if hasElement(plugin, "bodyName"):
+                touchSensorParent = None
+                name = plugin.getElementsByTagName('bodyName')[0].firstChild.nodeValue
+                for link in linkList:
+                    if link.name == name:
+                        touchSensorParent = link
+                        break
+                if touchSensorParent:
+                    touchSensorParent.touchSensor = touchSensor
     for sensorElement in element.getElementsByTagName('sensor'):
         sensorElement = element.getElementsByTagName('sensor')[0]
         if sensorElement.getAttribute('type') == 'camera':

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -356,7 +356,7 @@ class TouchSensor:
         """Export the touch sensor."""
         indent = '  '
         if self.type:
-            file.write(indentationLevel * indent + '  type "%s"\n' % self.type)
+            file.write(indentationLevel * indent + 'type "%s"\n' % self.type)
 
 
 def colorVector2Instance(cv, alpha_last=True):

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -94,7 +94,11 @@ def URDFLink(proto, link, level, parentList, childList, linkList, jointList, sen
         proto.write((level + 1) * indent + 'synchronization IS synchronization\n')
         proto.write((level + 1) * indent + 'selfCollision IS selfCollision\n')
     else:
-        proto.write((' ' if endpoint else level * indent) + 'Solid {\n')
+        if link.touchSensor:
+            proto.write((' ' if endpoint else level * indent) + 'TouchSensor {\n')
+            link.touchSensor.export(proto, level + 1)
+        else:
+            proto.write((' ' if endpoint else level * indent) + 'Solid {\n')
         proto.write((level + 1) * indent + 'translation %lf %lf %lf\n' % (jointPosition[0],
                                                                           jointPosition[1],
                                                                           jointPosition[2]))

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -94,9 +94,9 @@ def URDFLink(proto, link, level, parentList, childList, linkList, jointList, sen
         proto.write((level + 1) * indent + 'synchronization IS synchronization\n')
         proto.write((level + 1) * indent + 'selfCollision IS selfCollision\n')
     else:
-        if link.touchSensor:
+        if link.forceSensor:
             proto.write((' ' if endpoint else level * indent) + 'TouchSensor {\n')
-            link.touchSensor.export(proto, level + 1)
+            proto.write((level + 1) * indent + 'type "force-3d"\n')
         else:
             proto.write((' ' if endpoint else level * indent) + 'Solid {\n')
         proto.write((level + 1) * indent + 'translation %lf %lf %lf\n' % (jointPosition[0],


### PR DESCRIPTION
This PR adds causes a TouchSensor to be generated for each "libgazebo_ros_f3d.so" plugin. 

Since a Touch sensor needs to have a bounding object, the adding of the sensor has to work a little bit different for this sensor. The node type which represents this link is changed into a TouchSensor.

The difference between the protos is only in the first two lines.

The resulting proto (after PR) looks like this:
```
TouchSensor {
  type "force-3d"
  translation -0.030000 -0.007000 -0.034000
  rotation -0.000000 0.000000 -1.000000 1.570800
  children [
    Wolfgang_rlbMesh {
    }
    Solid {
      translation 0.000000 -0.000500 -0.016000
      rotation -0.000000 0.000000 -1.000000 3.141590
      name "r_cleat_l_back"
    }
  ]
  name "rlb"
  boundingObject Transform {
    translation 0.000000 0.000000 -0.008000
    rotation 0.000000 1.000000 0.000000 0.000000
    children [
      Box {
        size 0.012000 0.012000 0.016000
      }
    ]
  }
  physics Physics {
    density -1
    mass 0.001660
    centerOfMass [ 0.000000 0.000156 -0.007759 ]
    inertiaMatrix [
      4.335200e-08 4.440490e-08 3.043970e-08
      4.172760e-26 1.815160e-25 -1.099300e-09
    ]
  }
}
```

Where it was this before:
```
Solid {
  translation -0.030000 -0.007000 -0.034000
  rotation -0.000000 0.000000 -1.000000 1.570800
  children [
    Wolfgang_rlbMesh {
    }
    Solid {
      translation 0.000000 -0.000500 -0.016000
      rotation -0.000000 0.000000 -1.000000 3.141590
      name "r_cleat_l_back"
    }
  ]
  name "rlb"
  boundingObject Transform {
    translation 0.000000 0.000000 -0.008000
    rotation 0.000000 1.000000 0.000000 0.000000
    children [
      Box {
        size 0.012000 0.012000 0.016000
      }
    ]
  }
  physics Physics {
    density -1
    mass 0.001660
    centerOfMass [ 0.000000 0.000156 -0.007759 ]
    inertiaMatrix [
      4.335200e-08 4.440490e-08 3.043970e-08
      4.172760e-26 1.815160e-25 -1.099300e-09
    ]
  }
}
```