### PR TITLE
add option to use link names as DEF names

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ pip install -r requirements.txt
 ### From pip
 
 ```
-python -m urdf2webots.importer --input=someRobot.urdf [--output=outputFile] [--box-collision] [--normal] [--disable-mesh-optimization] [--multi-file] [--static-base] [--tool-slot=linkName] [--help]
+python -m urdf2webots.importer --input=someRobot.urdf [--output=outputFile] [--box-collision] [--normal] [--disable-mesh-optimization] [--multi-file] [--static-base] [--tool-slot=linkName] [--name-to-def] [--help]
 ```
 
 ### From Sources
 
 ```
-python demo.py --input=someRobot.urdf [--output=outputFile] [--box-collision] [--normal] [--disable-mesh-optimization] [--multi-file] [--static-base] [--tool-slot=linkName] [--help]
+python demo.py --input=someRobot.urdf [--output=outputFile] [--box-collision] [--normal] [--disable-mesh-optimization] [--multi-file] [--static-base] [--tool-slot=linkName] [--name-to-def] [--help]
 ```
 
 ### Arguments
@@ -50,12 +50,13 @@ The script accepts the following arguments:
   - **--tool-slot=LinkName**: Specify the link that you want to add a tool slot to (exact link name from urdf).
   - **--rotation="0 1 0 0"**: Set the rotation field of your PROTO file. If your URDF file uses the z-axis as 'up', use `--rotation="1 0 0 -1.5708"`.
   - **--init-pos=JointPositions**: Set the initial positions of your robot joints. Example: `--init-pos="[1.2, 0.5, -1.5]"` would set the first 3 joints of your robot to the specified values, and leave the rest with their default value.
+  - **--name-to-def**: Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName)
 
 ### In your Python Code
 
 ```
 from urdf2webots.importer import convert2urdf
-convert2urdf('MY_PATH/MY_URDF.urd')
+convert2urdf('MY_PATH/MY_URDF.urdf')
 ```
 
 ### In-Depth Tutorial

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The script accepts the following arguments:
   - **--tool-slot=LinkName**: Specify the link that you want to add a tool slot to (exact link name from urdf).
   - **--rotation="0 1 0 0"**: Set the rotation field of your PROTO file. If your URDF file uses the z-axis as 'up', use `--rotation="1 0 0 -1.5708"`.
   - **--init-pos=JointPositions**: Set the initial positions of your robot joints. Example: `--init-pos="[1.2, 0.5, -1.5]"` would set the first 3 joints of your robot to the specified values, and leave the rest with their default value.
-  - **--name-to-def**: Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName)
+  - **--link-to-def**: Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName)
+  - **--joint-to-def**: Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName)
 
 ### In your Python Code
 

--- a/demo.py
+++ b/demo.py
@@ -30,9 +30,11 @@ if __name__ == '__main__':
     optParser.add_option('--init-pos', dest='initPos', default=None,
                          help='Set the initial positions of your robot joints. Example: --init-pos="[1.2, 0.5, -1.5]" would set '
                          'the first 3 joints of your robot to the specified values, and leave the rest with their default value.')
-    optParser.add_option('--name-to-def', dest='nameToDef', action='store_true', default=False,
+    optParser.add_option('--link-to-def', dest='linkToDef', action='store_true', default=False,
                          help='If set, urdf link names are also used as DEF names as well as solid names.')
+    optParser.add_option('--joint-to-def', dest='jointToDef', action='store_true', default=False,
+                         help='If set, urdf joint names are also used as DEF names as well as joint names.')
     options, args = optParser.parse_args()
 
     convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization,
-                 options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos, options.nameToDef)
+                 options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos, options.linkToDef, options.jointToDef)

--- a/demo.py
+++ b/demo.py
@@ -30,7 +30,9 @@ if __name__ == '__main__':
     optParser.add_option('--init-pos', dest='initPos', default=None,
                          help='Set the initial positions of your robot joints. Example: --init-pos="[1.2, 0.5, -1.5]" would set '
                          'the first 3 joints of your robot to the specified values, and leave the rest with their default value.')
+    optParser.add_option('--name-to-def', dest='nameToDef', action='store_true', default=False,
+                         help='If set, urdf link names are also used as DEF names as well as solid names.')
     options, args = optParser.parse_args()
 
     convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization,
-                 options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos)
+                 options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos, options.nameToDef)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -48,7 +48,7 @@ def mkdirSafe(directory):
 
 def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
                  disableMeshOptimization=False, enableMultiFile=False, staticBase=False, toolSlot=None,
-                 initRotation='0 1 0 0', initPos=None, nameToDef=False):
+                 initRotation='0 1 0 0', initPos=None, linkToDef=False, jointToDef=False):
     if not os.path.exists(inFile):
         sys.exit('Input file "%s" does not exists.' % inFile)
     if not type(initRotation) == str or len(initRotation.split()) != 4:
@@ -66,7 +66,8 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
     urdf2webots.writeProto.staticBase = staticBase
     urdf2webots.writeProto.toolSlot = toolSlot
     urdf2webots.writeProto.initPos = initPos
-    urdf2webots.writeProto.nameToDef = nameToDef
+    urdf2webots.writeProto.linkToDef = linkToDef
+    urdf2webots.writeProto.jointToDef = jointToDef
 
     with open(inFile, 'r') as file:
         inPath = os.path.dirname(os.path.abspath(inFile))
@@ -212,8 +213,10 @@ if __name__ == '__main__':
                          help='Set the initial positions of your robot joints. Example: --init-pos="[1.2, 0.5, -1.5]" would '
                          'set the first 3 joints of your robot to the specified values, and leave the rest with their '
                          'default value')
-    optParser.add_option('--name-to-def', dest='nameToDef', action='store_true', default=False,
+    optParser.add_option('--link-to-def', dest='linkToDef', action='store_true', default=False,
                          help='If set, urdf link names are also used as DEF names as well as solid names.')
+    optParser.add_option('--joint-to-def', dest='jointToDef', action='store_true', default=False,
+                         help='If set, urdf joint names are also used as DEF names as well as joint names.')
     options, args = optParser.parse_args()
     convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization,
-                 options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos, options.nameToDef)
+                 options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos, options.linkToDef, options.jointToDef)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -48,7 +48,7 @@ def mkdirSafe(directory):
 
 def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
                  disableMeshOptimization=False, enableMultiFile=False, staticBase=False, toolSlot=None,
-                 initRotation='0 1 0 0', initPos=None):
+                 initRotation='0 1 0 0', initPos=None, nameToDef=False):
     if not os.path.exists(inFile):
         sys.exit('Input file "%s" does not exists.' % inFile)
     if not type(initRotation) == str or len(initRotation.split()) != 4:
@@ -66,6 +66,7 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
     urdf2webots.writeProto.staticBase = staticBase
     urdf2webots.writeProto.toolSlot = toolSlot
     urdf2webots.writeProto.initPos = initPos
+    urdf2webots.writeProto.nameToDef = nameToDef
 
     with open(inFile, 'r') as file:
         inPath = os.path.dirname(os.path.abspath(inFile))
@@ -211,7 +212,8 @@ if __name__ == '__main__':
                          help='Set the initial positions of your robot joints. Example: --init-pos="[1.2, 0.5, -1.5]" would '
                          'set the first 3 joints of your robot to the specified values, and leave the rest with their '
                          'default value')
+    optParser.add_option('--name-to-def', dest='nameToDef', action='store_true', default=False,
+                         help='If set, urdf link names are also used as DEF names as well as solid names.')
     options, args = optParser.parse_args()
-
     convert2urdf(options.inFile, options.outFile, options.normal, options.boxCollision, options.disableMeshOptimization,
-                 options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos)
+                 options.enableMultiFile, options.staticBase, options.toolSlot, options.initRotation, options.initPos, options.nameToDef)

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -11,7 +11,8 @@ enableMultiFile = False
 meshFilesPath = None
 robotNameMain = ''
 initPos = None
-nameToDef = False
+linkToDef = False
+jointToDef = False
 
 
 class RGB():
@@ -96,10 +97,10 @@ def URDFLink(proto, link, level, parentList, childList, linkList, jointList, sen
         proto.write((level + 1) * indent + 'selfCollision IS selfCollision\n')
     else:
         if link.forceSensor:
-            proto.write((' ' if endpoint else level * indent) + ('DEF ' + link.name + ' ' if nameToDef else '') + 'TouchSensor {\n')
+            proto.write((' ' if endpoint else level * indent) + ('DEF ' + link.name + ' ' if linkToDef else '') + 'TouchSensor {\n')
             proto.write((level + 1) * indent + 'type "force-3d"\n')
         else:
-            proto.write((' ' if endpoint else level * indent) + ('DEF ' + link.name + ' ' if nameToDef else '') + 'Solid {\n')
+            proto.write((' ' if endpoint else level * indent) + ('DEF ' + link.name + ' ' if linkToDef else '') + 'Solid {\n')
         proto.write((level + 1) * indent + 'translation %lf %lf %lf\n' % (jointPosition[0],
                                                                           jointPosition[1],
                                                                           jointPosition[2]))
@@ -539,7 +540,7 @@ def URDFJoint(proto, joint, level, parentList, childList, linkList, jointList,
     if joint.rotation[3] != 0.0 and axis:
         axis = rotateVector(axis, joint.rotation)
     if joint.type == 'revolute' or joint.type == 'continuous':
-        proto.write(level * indent + 'HingeJoint {\n')
+        proto.write(level * indent + ('DEF ' + joint.name + ' ' if jointToDef else '') + 'HingeJoint {\n')
         proto.write((level + 1) * indent + 'jointParameters HingeJointParameters {\n')
         position = None
         if joint.limit.lower > 0.0:
@@ -565,7 +566,7 @@ def URDFJoint(proto, joint, level, parentList, childList, linkList, jointList,
         proto.write((level + 1) * indent + 'device [\n')
         proto.write((level + 2) * indent + 'RotationalMotor {\n')
     elif joint.type == 'prismatic':
-        proto.write(level * indent + 'SliderJoint {\n')
+        proto.write(level * indent + ('DEF ' + joint.name + ' ' if jointToDef else '') + 'SliderJoint {\n')
         proto.write((level + 1) * indent + 'jointParameters JointParameters {\n')
         if joint.limit.lower > 0.0:
             # if 0 is not in the range, set the position to be the middle of the range

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -96,7 +96,7 @@ def URDFLink(proto, link, level, parentList, childList, linkList, jointList, sen
         proto.write((level + 1) * indent + 'selfCollision IS selfCollision\n')
     else:
         if link.forceSensor:
-            proto.write((' ' if endpoint else level * indent) + 'TouchSensor {\n')
+            proto.write((' ' if endpoint else level * indent) + ('DEF ' + link.name + ' ' if nameToDef else '') + 'TouchSensor {\n')
             proto.write((level + 1) * indent + 'type "force-3d"\n')
         else:
             proto.write((' ' if endpoint else level * indent) + ('DEF ' + link.name + ' ' if nameToDef else '') + 'Solid {\n')

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -11,6 +11,7 @@ enableMultiFile = False
 meshFilesPath = None
 robotNameMain = ''
 initPos = None
+nameToDef = False
 
 
 class RGB():
@@ -98,7 +99,7 @@ def URDFLink(proto, link, level, parentList, childList, linkList, jointList, sen
             proto.write((' ' if endpoint else level * indent) + 'TouchSensor {\n')
             proto.write((level + 1) * indent + 'type "force-3d"\n')
         else:
-            proto.write((' ' if endpoint else level * indent) + 'Solid {\n')
+            proto.write((' ' if endpoint else level * indent) + ('DEF ' + link.name + ' ' if nameToDef else '') + 'Solid {\n')
         proto.write((level + 1) * indent + 'translation %lf %lf %lf\n' % (jointPosition[0],
                                                                           jointPosition[1],
                                                                           jointPosition[2]))


### PR DESCRIPTION
To retrieve Nodes in the controller it is useful to use the function getFromProtoDef(<def_name>).

This pr adds an option to use the urdf link names as DEF names (in addition to solid names).