### PR TITLE
handle gazebo sensor type gpu_ray same as ray

### DIFF
--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -969,7 +969,7 @@ def parseGazeboElement(element, parentLink, linkList):
                 if hasElement(noiseElement, 'stddev'):
                     camera.noise = float(noiseElement.getElementsByTagName('stddev')[0].firstChild.nodeValue)
             Camera.list.append(camera)
-        elif sensorElement.getAttribute('type') == 'ray':
+        elif sensorElement.getAttribute('type') == 'ray' or sensorElement.getAttribute('type') == 'gpu_ray':
             lidar = Lidar()
             lidar.parentLink = parentLink
             lidar.name = sensorElement.getAttribute('name')


### PR DESCRIPTION
`gpu_ray` seems to be a sensor type in gazebo sensor plugins. (see #109)

After this PR they are handled the same as a normal Lidar sensor.