### PR TITLE
Fix typo in IMU parser

### DIFF
--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -269,7 +269,7 @@ class IMU():
         file.write(indentationLevel * indent + '  name "%s compass"\n' % self.name)
         if self.gaussianNoise > 0:
             file.write(indentationLevel * indent + '  lookupTable [-1 -1 %lf, 1 1 %lf]\n' %
-                       -self.gaussianNoise, self.gaussianNoise)
+                       (-self.gaussianNoise, self.gaussianNoise))
         file.write(indentationLevel * indent + '}\n')
 
 


### PR DESCRIPTION
There was a missing parenthesis that raised an error when converting a robot containing an IMU with non-zero Gaussian noise.