### PR TITLE
Proposal: Fix handling of texture images

### DIFF
--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -580,6 +580,9 @@ def getColladaMesh(filename, node, link):
                                             except IOError:
                                                 visual.material.texture = ""
                                                 print('failed to open ' + os.path.join(dirname, file))
+                            else:
+                                visual.material.diffuse = colorVector2Instance([1.0, 1.0, 1.0, 1.0])
+
                 link.visual.append(visual)
     else:
         for geometry in list(colladaMesh.scene.objects('geometry')):

--- a/urdf2webots/writeProto.py
+++ b/urdf2webots/writeProto.py
@@ -372,6 +372,10 @@ def URDFVisual(proto, visualNode, level, normal=False):
             proto.write((shapeLevel + 2) * indent + 'baseColorMap ImageTexture {\n')
             proto.write((shapeLevel + 3) * indent + 'url [ "' + visualNode.material.texture + '" ]\n')
             proto.write((shapeLevel + 2) * indent + '}\n')
+
+            proto.write((shapeLevel + 2) * indent + 'textureTransform TextureTransform {\n')
+            proto.write((shapeLevel + 3) * indent + 'scale 1 -1\n')
+            proto.write((shapeLevel + 2) * indent + '}\n')
         proto.write((shapeLevel + 1) * indent + '}\n')
 
     if visualNode.geometry.box.x != 0:


### PR DESCRIPTION
This merge request is intended for discussion about the current state of handling texture images. When texture images are used in combination with Collada mesh files, I encountered two issues that are addressed by this commit:

* When no tif file is provided, then the baseColor will be computed incorrectly later on (see [here](https://github.com/cyberbotics/urdf2webots/blob/48f0143d484dc6c9879ed11e437d1dc315fce657/urdf2webots/writeProto.py#L362)), which results in dark rendered images. This wrong behavior is fixed by setting visual.material.diffuse to a default value when a texture image is detected.

* The texture image coordinate system used by Webots differs from the commonly used system resulting in upside-down rendered images. This effect has been already described in an old [reference manual](http://edge.rit.edu/edge/P16201/public/P16201%20Google%20Drive%20Files/Tigerbot/P15201%20Documents/MSD/MSD%20I/WeBots_reference.pdf) in section 3.24.3. This commit includes the proposed transform by default.

Feedback is appreciated!