### PR TITLE
Implemented P3D object for ground truth pose output by Webots

### DIFF
--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -176,6 +176,7 @@ def convert2urdf(inFile, outFile=None, normal=False, boxCollision=False,
                         urdf2webots.parserURDF.parseGazeboElement(child, rootLink.name, linkList)
 
                 sensorList = (urdf2webots.parserURDF.IMU.list +
+                              urdf2webots.parserURDF.P3D.list +
                               urdf2webots.parserURDF.Camera.list +
                               urdf2webots.parserURDF.Lidar.list)
                 print('There are %d links, %d joints and %d sensors' % (len(linkList), len(jointList), len(sensorList)))

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -991,6 +991,10 @@ def parseGazeboElement(element, parentLink, linkList):
             p3d.parentLink = parentLink
             if hasElement(plugin, 'topicName'):
                 p3d.name = plugin.getElementsByTagName('topicName')[0].firstChild.nodeValue
+            if hasElement(plugin, "xyzOffsets"):
+                print('\033[1;33mWarning: URDF parser cannot handle \"xyzOffsets\" from p3d!\033[0m')
+            if hasElement(plugin, "rpyOffsets"):
+                print('\033[1;33mWarning: URDF parser cannot handle \"rpyOffsets\" from p3d!\033[0m')
             P3D.list.append(p3d)
     for sensorElement in element.getElementsByTagName('sensor'):
         sensorElement = element.getElementsByTagName('sensor')[0]


### PR DESCRIPTION
Adds P3D object that is created when parsing a "libgazebo_ros_p3d" from the URDF file. Aftward, all required Nodes (GPS, InertialUnit and Gyro) are added to the referred link, which then can be used, e.g. to implement a ground truth publisher node.