### PR TITLE
fix parsing of vertical rays

### DIFF
--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -1055,13 +1055,13 @@ def parseGazeboElement(element, parentLink, linkList):
                             maxAngle = float(horizontalElement.getElementsByTagName('max_angle')[0].firstChild.nodeValue)
                             lidar.fov = maxAngle - minAngle
                     if hasElement(scanElement, 'vertical'):
-                        horizontalElement = scanElement.getElementsByTagName('horizontal')[0]
-                        if hasElement(horizontalElement, 'samples'):
+                        verticalElement = scanElement.getElementsByTagName('vertical')[0]
+                        if hasElement(verticalElement, 'samples'):
                             lidar.numberOfLayers = \
-                              int(horizontalElement.getElementsByTagName('samples')[0].firstChild.nodeValue)
-                        if hasElement(horizontalElement, 'min_angle') and hasElement(horizontalElement, 'max_angle'):
-                            minAngle = float(horizontalElement.getElementsByTagName('min_angle')[0].firstChild.nodeValue)
-                            maxAngle = float(horizontalElement.getElementsByTagName('max_angle')[0].firstChild.nodeValue)
+                              int(verticalElement.getElementsByTagName('samples')[0].firstChild.nodeValue)
+                        if hasElement(verticalElement, 'min_angle') and hasElement(verticalElement, 'max_angle'):
+                            minAngle = float(verticalElement.getElementsByTagName('min_angle')[0].firstChild.nodeValue)
+                            maxAngle = float(verticalElement.getElementsByTagName('max_angle')[0].firstChild.nodeValue)
                             lidar.verticalFieldOfView = maxAngle - minAngle
                 if hasElement(rayElement, 'range'):
                     rangeElement = rayElement.getElementsByTagName('range')[0]


### PR DESCRIPTION
The `vertical` part of someting like this was being incorrectly parsed:

```
<ray>
    <noise type="gaussian">
        <mean>0.0</mean>
        <stddev>0.00</stddev>
        <bias_mean>0.00</bias_mean>
        <bias_stddev>0.00</bias_stddev>
    </noise>
    <scan>
        <horizontal>
            <samples>200</samples>
            <min_angle>-0.55</min_angle>
            <max_angle>0.55</max_angle>
        </horizontal>
        <vertical>
            <samples>5</samples>
            <min_angle>-0.10</min_angle>
            <max_angle>0.10</max_angle>
        </vertical>
    </scan>
    <range>
        <min>0.05</min>
        <max>5.0</max>
    </range>
</ray>
```