### PR TITLE
prepare version 1.0.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='urdf2webots',
-    version='1.0.10',
+    version='1.0.11',
     author='Cyberbotics',
     author_email='support@cyberbotics.com',
     description='A converter between URDF and PROTO files.',


### PR DESCRIPTION
This prepare the new release version `1.0.11`.

I assume as the precedent version in file `setup.py` was `1.0.10` that the name of the release on the repo `10.0.10` has a typo, and thus the next release will be `1.0.11`.