### PR TITLE
Change the link for the base_link file and correct it for the tutorial kuka

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -28,6 +28,9 @@ source devel/setup.bash
 `kuka_experimental/kuka_lbr_iiwa_support/meshes/lbr_iiwa_14_r820/visual/base_link.dae`
 with this (original file is corrupted):
 [base_link.dae](./assets/files/base_link.dae)
+```
+cp ~/Downloads/base_link.dae src/kuka_experimental/kuka_lbr_iiwa_support/meshes/lbr_iiwa_14_r820/visual/base_link.dae
+```
 
 To follow the below instructions, you'll need to have the `xacro` tool installed; some ROS installations don't include it by default. If you don't have it, you can install it as follows on Ubuntu (substitute your ROS distribution for "noetic"):
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -27,7 +27,7 @@ source devel/setup.bash
 **Note:** If you want to convert this exact same robot, you will have to replace the file at
 `kuka_experimental/kuka_lbr_iiwa_support/meshes/lbr_iiwa_14_r820/visual/base_link.dae`
 with this (original file is corrupted):
-[base_link.dae](https://drive.google.com/file/d/1J0dVuDOW7k3wa6Gj0vpjKzlNMzQHOAfD/view?usp=sharing)
+[base_link.dae](./assets/files/base_link.dae)
 
 To follow the below instructions, you'll need to have the `xacro` tool installed; some ROS installations don't include it by default. If you don't have it, you can install it as follows on Ubuntu (substitute your ROS distribution for "noetic"):
 ```


### PR DESCRIPTION
I changed the file `base_link` int the Kuka tutorial as it had multiple occurrences of the same id for cameras and lights, thus when we imported the PROTO in Webots the `base` was showing errors.

Solve partially #137 