### PR TITLE
Remove special rotation for cylinders

### DIFF
--- a/urdf2webots/math_utils.py
+++ b/urdf2webots/math_utils.py
@@ -26,8 +26,8 @@ def rotationFromQuaternion(q):
     if (v[3] < 0.0001):
         # if v[3] close to zero then direction of axis not important
         v[0] = 0.0
-        v[1] = 0.0
-        v[2] = 1.0
+        v[1] = 1.0
+        v[2] = 0.0
     else:
         # normalise axes
         n = math.sqrt(q[1] * q[1] + q[2] * q[2] + q[3] * q[3])

--- a/urdf2webots/math_utils.py
+++ b/urdf2webots/math_utils.py
@@ -26,8 +26,8 @@ def rotationFromQuaternion(q):
     if (v[3] < 0.0001):
         # if v[3] close to zero then direction of axis not important
         v[0] = 0.0
-        v[1] = 1.0
-        v[2] = 0.0
+        v[1] = 0.0
+        v[2] = 1.0
     else:
         # normalise axes
         n = math.sqrt(q[1] * q[1] + q[2] * q[2] + q[3] * q[3])
@@ -37,10 +37,8 @@ def rotationFromQuaternion(q):
     return v
 
 
-def convertRPYtoQuaternions(rpy, cylinder=False):
+def convertRPYtoQuaternions(rpy):
     """Convert RPY to quaternions."""
-    if cylinder:
-        rpy[0] += 0.5 * math.pi
     cy = math.cos(rpy[2] * 0.5)
     sy = math.sin(rpy[2] * 0.5)
     cp = math.cos(rpy[1] * 0.5)
@@ -56,9 +54,9 @@ def convertRPYtoQuaternions(rpy, cylinder=False):
     return q
 
 
-def convertRPYtoEulerAxis(rpy, cylinder=False):
+def convertRPYtoEulerAxis(rpy):
     """Convert RPY angles to Euler angles."""
-    return rotationFromQuaternion(convertRPYtoQuaternions(rpy, cylinder))
+    return rotationFromQuaternion(convertRPYtoQuaternions(rpy))
 
 
 def multiplyMatrix(mat1, mat2):

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -356,7 +356,6 @@ class Camera():
         """Export this camera."""
         indent = '  '
         file.write(indentationLevel * indent + 'Camera {\n')
-        # rotation to convert from REP103 to webots viewport
         file.write(indentationLevel * indent + '  name "%s"\n' % self.name)
         if self.fov:
             file.write(indentationLevel * indent + '  fieldOfView %lf\n' % self.fov)
@@ -554,7 +553,7 @@ def getPosition(node):
     return position
 
 
-def getRotation(node, isCylinder=False):
+def getRotation(node):
     """Read rotation of a phsical or visual object."""
     rotation = [0.0, 0.0, 0.0]
     if hasElement(node, 'origin'):
@@ -562,10 +561,7 @@ def getRotation(node, isCylinder=False):
         rotation[0] = float(orientationString[0])
         rotation[1] = float(orientationString[1])
         rotation[2] = float(orientationString[2])
-    if isCylinder:
-        return convertRPYtoEulerAxis(rotation, True)
-    else:
-        return convertRPYtoEulerAxis(rotation, False)
+    return convertRPYtoEulerAxis(rotation)
 
 
 def getInertia(node):
@@ -599,12 +595,9 @@ def getVisual(link, node, path):
             if visualElement.getElementsByTagName('origin')[0].getAttribute('xyz'):
                 visual.position = getPosition(visualElement)
             if visualElement.getElementsByTagName('origin')[0].getAttribute('rpy'):
-                if hasElement(visualElement.getElementsByTagName('geometry')[0], 'cylinder'):
-                    visual.rotation = getRotation(visualElement, True)
-                else:
-                    visual.rotation = getRotation(visualElement)
+                visual.rotation = getRotation(visualElement)
         elif hasElement(visualElement.getElementsByTagName('geometry')[0], 'cylinder'):
-            visual.rotation = getRotation(visualElement, True)
+            visual.rotation = getRotation(visualElement)
 
         geometryElement = visualElement.getElementsByTagName('geometry')[0]
 
@@ -708,12 +701,9 @@ def getCollision(link, node, path):
             if collisionElement.getElementsByTagName('origin')[0].getAttribute('xyz'):
                 collision.position = getPosition(collisionElement)
             if collisionElement.getElementsByTagName('origin')[0].getAttribute('rpy'):
-                if hasElement(collisionElement.getElementsByTagName('geometry')[0], 'cylinder'):
-                    collision.rotation = getRotation(collisionElement, True)
-                else:
-                    collision.rotation = getRotation(collisionElement)
+                collision.rotation = getRotation(collisionElement)
         elif hasElement(collisionElement.getElementsByTagName('geometry')[0], 'cylinder'):
-            collision.rotation = getRotation(collisionElement, True)
+            collision.rotation = getRotation(collisionElement)
 
         geometryElement = collisionElement.getElementsByTagName('geometry')[0]
         if hasElement(geometryElement, 'box'):


### PR DESCRIPTION
Some URDF files were not correctly converted, as some links were not rotated in the correct way. This was due to a special case for the cylinder before the conversion to FLU/ENU.

This PR remove this exception.