### PR TITLE
Removing image coordinate flipping

### DIFF
--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -449,7 +449,7 @@ def URDFVisual(robotFile, visualNode, level, normal=False):
                 robotFile.write((shapeLevel + 2) * indent + '}\n')
 
                 robotFile.write((shapeLevel + 2) * indent + 'textureTransform TextureTransform {\n')
-                robotFile.write((shapeLevel + 3) * indent + 'scale 1 -1\n')
+                robotFile.write((shapeLevel + 3) * indent + 'scale 1 1\n')
                 robotFile.write((shapeLevel + 2) * indent + '}\n')
             robotFile.write((shapeLevel + 1) * indent + '}\n')
 

--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -447,10 +447,6 @@ def URDFVisual(robotFile, visualNode, level, normal=False):
                 robotFile.write((shapeLevel + 2) * indent + 'baseColorMap ImageTexture {\n')
                 robotFile.write((shapeLevel + 3) * indent + 'url [ "' + visualNode.material.texture + '" ]\n')
                 robotFile.write((shapeLevel + 2) * indent + '}\n')
-
-                robotFile.write((shapeLevel + 2) * indent + 'textureTransform TextureTransform {\n')
-                robotFile.write((shapeLevel + 3) * indent + 'scale 1 1\n')
-                robotFile.write((shapeLevel + 2) * indent + '}\n')
             robotFile.write((shapeLevel + 1) * indent + '}\n')
 
     if visualNode.geometry.box.x != 0:


### PR DESCRIPTION
I think I've seen also a changelog addressing changes in Webots coordinate systems, but cannot find it anymore. However, the coordinate flipping for textures isn't necessary anymore using the latest version of Webots.