### PR TITLE
Enable conversion from URDF content

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
       matrix:
         python: [3.5, 3.6, 3.7, 3.8]
     runs-on: ubuntu-latest
+    env:
+      CI: 1
     steps:
     - uses: actions/checkout@v2
       with:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ The script accepts the following arguments:
   - **--link-to-def**: Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
   - **--joint-to-def**: Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
 
-In case of the **--input** command line is missing, the conversion tool will read the content of `stdin`. You might simply copy-past the content of your URDF file in the terminal. Unfortunately the conversion tool will not be able to deal with relative paths present in your URDF file if you chose to not specify **--input**.
+In case the **--input** option is missing, the script will read the URDF content from `stdin`.
+In that case, you can pipe the content of your URDF file into the script: `cat my_robot.urdf | urdf2proto.py`.
+Relative paths present in your URDF file will be treated relatively to the current directory from which the script is called.
 
 > Previously the **--static-base** argument was supported in order to set the base link to be static (disabled physics). It has been removed as there is a better way to do it by adding the following to your URDF file (assuming **base_link** is the root link of your robot):
 >

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python -m urdf2webots.importer --input=someRobot.urdf [--output=outputFile] [--n
 
 The script accepts the following arguments:
   - **-h, --help**: Show the help message and exit.
-  - **--input=INPUT**: Specifies the URDF file or the URDF content string to convert.
+  - **--input=INPUT**: Specifies the URDF file to convert or the URDF content string.
   - **--output=OUTFILE**: If set, specifies the path and, if ending in ".proto", name of the resulting PROTO file. The filename minus the .proto extension will be the robot name (for PROTO conversion only).
   - **--robot-name**: Specify the name of the robot and generate a Robot node string instead of a PROTO file (has to be unique).
   - **--normal**: If set, the normals are exported if present in the URDF definition.
@@ -45,6 +45,8 @@ The script accepts the following arguments:
   - **--init-pos=JointPositions**: Set the initial positions of your robot joints. Example: `--init-pos="[1.2, 0.5, -1.5]"` would set the first 3 joints of your robot to the specified values, and leave the rest with their default value.
   - **--link-to-def**: Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
   - **--joint-to-def**: Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
+
+> In case of a conversion from a URDF content string, it is easier to do it in [Python](#in-your-python-code).
 
 > Previously the **--static-base** argument was supported in order to set the base link to be static (disabled physics). It has been removed as there is a better way to do it by adding the following to your URDF file (assuming **base_link** is the root link of your robot):
 >

--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ The command line arguments available from the terminal are also available from t
 | --link-to-def |  linkToDef |
 | --joint-to-def |  jointToDef |
 
-In Python, you are able to convert your URDF file by using its path as input to the `convertUrdfFile()` function or directly by giving its content as input to the `convertUrdfContent()` function.
-
-Once again, the conversion tool will not be able to deal with relative paths present in your URDF file if you work with the `convertUrdfContent()` function.
+In Python, you can convert a URDF file by passing its path as an argument to the `convertUrdfFile()` function or directly by passing its content as an argument to the `convertUrdfContent()` function.
 
 #### Convert into Webots PROTO files
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ python -m urdf2webots.importer --input=someRobot.urdf [--output=outputFile] [--n
 
 The script accepts the following arguments:
   - **-h, --help**: Show the help message and exit.
-  - **--input=INFILE**: Specifies the urdf file to convert.
+  - **--input=INPUT**: Specifies the URDF file or the URDF content string to convert.
   - **--output=OUTFILE**: If set, specifies the path and, if ending in ".proto", name of the resulting PROTO file. The filename minus the .proto extension will be the robot name (for PROTO conversion only).
   - **--robot-name**: Specify the name of the robot and generate a Robot node string instead of a PROTO file (has to be unique).
   - **--normal**: If set, the normals are exported if present in the URDF definition.
   - **--box-collision**: If set, the bounding objects are approximated using boxes.
-  - **--tool-slot=LinkName**: Specify the link that you want to add a tool slot to (exact link name from urdf, for PROTO conversion only).
+  - **--tool-slot=LinkName**: Specify the link that you want to add a tool slot to (exact link name from URDF, for PROTO conversion only).
   - **--translation="0 0 0"**: Set the translation field of the PROTO file or Webots Robot node string.
   - **--rotation="0 0 1 0"**: Set the rotation field of the PROTO file or Webots Robot node string.
   - **--init-pos=JointPositions**: Set the initial positions of your robot joints. Example: `--init-pos="[1.2, 0.5, -1.5]"` would set the first 3 joints of your robot to the specified values, and leave the rest with their default value.
@@ -65,7 +65,7 @@ The command line arguments available from the terminal are also available from t
 
 | Terminal   |      Python      |
 |----------|-------------|
-| --input |  inFile |
+| --input |  input |
 | --output |  outFile |
 | --robot-name |  robotName |
 | --normal |  normal |
@@ -81,14 +81,32 @@ The command line arguments available from the terminal are also available from t
 
 ```
 from urdf2webots.importer import convert2urdf
-convert2urdf('MY_PATH/MY_URDF.urdf')
+convert2urdf(input = 'MY_PATH/MY_URDF.urdf')
+```
+
+or
+
+```
+import pathlib
+from urdf2webots.importer import convert2urdf
+robot_description = pathlib.Path('MY_PATH/MY_URDF.urdf').read_text()
+convert2urdf(input = robot_description)
 ```
 
 #### Convert into Webots Robot node strings
 
 ```
 from urdf2webots.importer import convert2urdf
-convert2urdf('MY_PATH/MY_URDF.urdf', isProto=False)
+convert2urdf(input = 'MY_PATH/MY_URDF.urdf', robotName="myRobot")
+```
+
+or
+
+```
+import pathlib
+from urdf2webots.importer import convert2urdf
+robot_description = pathlib.Path('MY_PATH/MY_URDF.urdf').read_text()
+convert2urdf(input = robot_description, robotName="myRobot")
 ```
 
 ### In-Depth Tutorial
@@ -96,6 +114,7 @@ Check out [this tutorial](./docs/tutorial.md) for a more in-depth, step by step 
 - Generate a URDF file from a ROS repository.
 - Convert your URDF file to a Webots PROTO file.
 - Load your converted model into Webots and make final adjustments.
+- Convert your URDF file to a Webots Robot string and import it.
 
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ python -m urdf2webots.importer --input=someRobot.urdf [--output=outputFile] [--n
 
 The script accepts the following arguments:
   - **-h, --help**: Show the help message and exit.
-  - **--input=INPUT**: Specifies the URDF file to convert or the URDF content string.
-  - **--output=OUTFILE**: If set, specifies the path and, if ending in ".proto", name of the resulting PROTO file. The filename minus the .proto extension will be the robot name (for PROTO conversion only).
+  - **--input=INPUT**: Specifies the URDF file to convert.
+  - **--output=OUTPUT**: If set, specifies the path and, if ending in ".proto", name of the resulting PROTO file. The filename minus the .proto extension will be the robot name (for PROTO conversion only).
   - **--robot-name**: Specify the name of the robot and generate a Robot node string instead of a PROTO file (has to be unique).
   - **--normal**: If set, the normals are exported if present in the URDF definition.
   - **--box-collision**: If set, the bounding objects are approximated using boxes.
@@ -46,7 +46,7 @@ The script accepts the following arguments:
   - **--link-to-def**: Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
   - **--joint-to-def**: Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
 
-> In case of a conversion from a URDF content string, it is easier to do it in [Python](#in-your-python-code).
+In case of the **--input** command line is missing, the conversion tool will read the content of `stdin`. You might simply copy-past the content of your URDF file in the terminal. Unfortunately the conversion tool will not be able to deal with relative paths present in your URDF file if you chose to not specify **--input**.
 
 > Previously the **--static-base** argument was supported in order to set the base link to be static (disabled physics). It has been removed as there is a better way to do it by adding the following to your URDF file (assuming **base_link** is the root link of your robot):
 >
@@ -63,12 +63,12 @@ The script accepts the following arguments:
 
 #### Arguments
 
-The command line arguments available from the terminal are also available from the python interface, but some have different names:
+The command line arguments available from the terminal are also available from the Python interface, but some have different names:
 
 | Terminal   |      Python      |
 |----------|-------------|
 | --input |  input |
-| --output |  outFile |
+| --output |  output |
 | --robot-name |  robotName |
 | --normal |  normal |
 | --box-collision |  boxCollision |
@@ -79,36 +79,40 @@ The command line arguments available from the terminal are also available from t
 | --link-to-def |  linkToDef |
 | --joint-to-def |  jointToDef |
 
+In Python, you are able to convert your URDF file by using its path as input to the `convertUrdfFile()` function or directly by giving its content as input to the `convertUrdfContent()` function.
+
+Once again, the conversion tool will not be able to deal with relative paths present in your URDF file if you work with the `convertUrdfContent()` function.
+
 #### Convert into Webots PROTO files
 
 ```
-from urdf2webots.importer import convert2urdf
-convert2urdf(input = 'MY_PATH/MY_URDF.urdf')
+from urdf2webots.importer import convertUrdfFile
+convertUrdfFile(input = 'MY_PATH/MY_URDF.urdf')
 ```
 
 or
 
 ```
 import pathlib
-from urdf2webots.importer import convert2urdf
+from urdf2webots.importer import convertUrdfContent
 robot_description = pathlib.Path('MY_PATH/MY_URDF.urdf').read_text()
-convert2urdf(input = robot_description)
+convertUrdfContent(input = robot_description)
 ```
 
 #### Convert into Webots Robot node strings
 
 ```
-from urdf2webots.importer import convert2urdf
-convert2urdf(input = 'MY_PATH/MY_URDF.urdf', robotName="myRobot")
+from urdf2webots.importer import convertUrdfFile
+convertUrdfFile(input = 'MY_PATH/MY_URDF.urdf', robotName="myRobot")
 ```
 
 or
 
 ```
 import pathlib
-from urdf2webots.importer import convert2urdf
+from urdf2webots.importer import convertUrdfContent
 robot_description = pathlib.Path('MY_PATH/MY_URDF.urdf').read_text()
-convert2urdf(input = robot_description, robotName="myRobot")
+convertUrdfContent(input = robot_description, robotName="myRobot")
 ```
 
 ### In-Depth Tutorial

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -147,5 +147,3 @@ from urdf2webots.importer import convertUrdfContent
 robot_description = pathlib.Path("model.urdf").read_text()
 convertUrdfContent(input=robot_description, robotName="myRobot")
 ```
-
-Be cautious, with this last method the converter tool can not deal with relative paths present in your URDF file!

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -121,7 +121,7 @@ You can achieve the exact same result as above by converting the URDF to a Webot
 First import the library:
 
 ```
-from urdf2webots.importer import convert2urdf
+from urdf2webots.importer import convertUrdfFile
 ```
 
 Then you will need to get the node where you will insert your robot. The most suitable place is at the last position in the scene tree.
@@ -135,6 +135,17 @@ children_field = root_node.getField('children')
 Finally you can convert your URDF file and add its corresponding robot to the simulation (be sure to set `robotName`, otherwise the tool will convert the URDF into a PROTO file):
 
 ```
-robot_string = convert2urdf(input=model.urdf, robotName="MyRobotName")
+robot_string = convertUrdfFile(input="model.urdf", robotName="MyRobotName")
 children_field.importMFNodeFromString(-1, robot_string)
 ```
+
+Note that you can also convert directly the content of your URDF file instead with:
+
+```
+import pathlib
+from urdf2webots.importer import convertUrdfContent
+robot_description = pathlib.Path("model.urdf").read_text()
+convertUrdfContent(input=robot_description, robotName="myRobot")
+```
+
+Be cautious, with this last method the converter tool can not deal with relative paths present in your URDF file!

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -135,6 +135,6 @@ children_field = root_node.getField('children')
 Finally you can convert your URDF file and add its corresponding robot to the simulation (be sure to set `robotName`, otherwise the tool will convert the URDF into a PROTO file):
 
 ```
-robot_string = convert2urdf(inFile=model.urdf, robotName="MyRobotName")
+robot_string = convert2urdf(input=model.urdf, robotName="MyRobotName")
 children_field.importMFNodeFromString(-1, robot_string)
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='urdf2webots',
-    version='1.0.14',
+    version='1.0.15',
     author='Cyberbotics',
     author_email='support@cyberbotics.com',
     description='A converter between URDF and PROTO files.',

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,8 +1,11 @@
 """Test module of the urdf2webots script."""
 import os
+import pathlib
+import pipes
+import shutil
 import sys
 import unittest
-import shutil
+
 from urdf2webots.importer import convert2urdf
 
 testDirectory = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
@@ -11,9 +14,12 @@ resultDirectory = os.path.join(testDirectory, 'results')
 expectedDirectory = os.path.join(testDirectory, 'expected')
 urdf2webotsPath = os.path.abspath(os.path.join(testDirectory, '..', 'urdf2webots/importer.py'))
 
+motoman_file_path = os.path.join(sourceDirectory, 'motoman/motoman_sia20d_support/urdf/sia20d.urdf')
+motoman_urdf_content = pathlib.Path(motoman_file_path).read_text()
+
 modelPathsProto = [
     {
-        'input': os.path.join(sourceDirectory, 'motoman/motoman_sia20d_support/urdf/sia20d.urdf'),
+        'input': motoman_file_path,
         'output': os.path.join(resultDirectory, 'MotomanSia20d.proto'),
         'expected': [os.path.join(expectedDirectory, 'MotomanSia20d.proto')],
         'arguments': '--multi-file --tool-slot=tool0 --rotation="1 0 0 0" --init-pos="[0.1, -0.1, 0.2]"'
@@ -28,6 +34,12 @@ modelPathsProto = [
         'input': os.path.join(sourceDirectory, 'kuka_lbr_iiwa_support/urdf/model.urdf'),
         'output': os.path.join(resultDirectory, 'KukaLbrIiwa14R820.proto'),
         'expected': [os.path.join(expectedDirectory, 'KukaLbrIiwa14R820.proto')],
+        'arguments': '--box-collision --tool-slot=tool0 --rotation="1 0 0 -1.5708"'
+    },
+    {
+        'input': pipes.quote(motoman_urdf_content),
+        'output': os.path.join(resultDirectory, 'MotomanSia20d_content.proto'),
+        'expected': [os.path.join(expectedDirectory, 'MotomanSia20d.proto')],
         'arguments': '--box-collision --tool-slot=tool0 --rotation="1 0 0 -1.5708"'
     }
 ]
@@ -86,7 +98,7 @@ class TestScript(unittest.TestCase):
 
         print("Robot node strings tests...")
         for paths in modelPathsRobotString:
-            robot_string = convert2urdf(inFile=paths['input'], robotName=paths['robotName'],
+            robot_string = convert2urdf(input=paths['input'], robotName=paths['robotName'],
                                         initTranslation=paths['translation'], initRotation=paths['rotation'])
             f = open(paths['output'], "a")
             f.write(robot_string)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -62,7 +62,7 @@ def convertUrdfFile(input = None, output=None, robotName=None, normal=False, box
     urdfContent = None
     if not input:
         print('''"--input" not specified, a URDF content will be read in the in stdin.\n
-            The "</robot>" tag will stop the lecture.''')
+            The "</robot>" tag will stop the reading.''')
         urdfContent = ""
         for line in sys.stdin:
             urdfContent += line

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -3,18 +3,25 @@
 """URDF files to Webots PROTO or Robot node converter."""
 
 
-import os
 import errno
 import optparse
-import tempfile
+import os
 import re
 import sys
+import tempfile
+from xml.dom import minidom
+
 import urdf2webots.parserURDF
 import urdf2webots.writeRobot
-from xml.dom import minidom
 
 try:
     import rospkg
+except ImportError:
+    pass
+
+try:
+    from ament_index_python import PackageNotFoundError
+    from ament_index_python.packages import get_package_share_directory
 except ImportError:
     pass
 
@@ -47,16 +54,18 @@ def mkdirSafe(directory):
             print('Directory "' + directory + '" already exists!')
 
 
-def convert2urdf(inFile, outFile=None, robotName=None, normal=False, boxCollision=False,
+def convert2urdf(input, outFile=None, robotName=None, normal=False, boxCollision=False,
                  disableMeshOptimization=False, enableMultiFile=False,
                  toolSlot=None, initTranslation='0 0 0', initRotation='0 0 1 0',
                  initPos=None, linkToDef=False, jointToDef=False):
-    if not inFile:
-        sys.exit('Input file not specified (should be specified with the "--input" argument).')
-    if not os.path.isfile(inFile):
-        sys.exit('Input file "%s" does not exists.' % inFile)
-    if not inFile.endswith('.urdf'):
-        sys.exit('"%s" is not an URDF file.' % inFile)
+    inputFile = None
+    if not input:
+        sys.exit('Input not specified (should be specified with the "--input" argument).')
+    if os.path.isfile(input):
+        print('convert2urdf will interpret input "%s" as a URDF file.' % input)
+        inputFile = input
+    else:
+        print('convert2urdf will interpret input as a URDF content string.')
 
     if not type(initTranslation) == str or len(initTranslation.split()) != 3:
         sys.exit('--translation argument is not valid. It has to be of Type = str and contain 3 values.')
@@ -97,145 +106,164 @@ def convert2urdf(inFile, outFile=None, robotName=None, normal=False, boxCollisio
     urdf2webots.parserURDF.Material.namedMaterial.clear()
     urdf2webots.parserURDF.Geometry.reference.clear()
 
-    with open(inFile, 'r') as file:
-        inPath = os.path.dirname(os.path.abspath(inFile))
-        content = file.read()
+    # Define the content according to the type of the input
+    content = None
+    if inputFile is not None:
+        with open(inputFile, 'r') as file:
+            content = file.read()
+        if content is None:
+            sys.exit('Could not read the URDF file.')
+    else:
+        content = input
 
-        for match in re.finditer('"package://(.*)"', content):
-            packageName = match.group(1).split('/')[0]
-            directory = inPath
-            while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
-                directory = os.path.dirname(directory)
-            if not os.path.split(directory)[1]:
+    # Replace "package://(.*)" occurences
+    if inputFile is None:
+        inPath = ""
+    else:
+        inPath = os.path.dirname(os.path.abspath(inputFile))
+
+    for match in re.finditer('"package://(.*)"', content):
+        packageName = match.group(1).split('/')[0]
+        directory = inPath
+        while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
+            directory = os.path.dirname(directory)
+        if not os.path.split(directory)[1]:
+            if 'ROS_VERSION' in os.environ and os.environ['ROS_VERSION'] == '1':
                 try:
                     rospack = rospkg.RosPack()
+                    print(str(rospack.list()))
                     directory = rospack.get_path(packageName)
                 except rospkg.common.ResourceNotFound:
                     sys.stderr.write('Package "%s" not found.\n' % packageName)
                 except NameError:
                     sys.stderr.write('Impossible to find location of "%s" package, installing "rospkg" might help.\n'
-                                     % packageName)
-            if os.path.split(directory)[1]:
-                packagePath = os.path.split(directory)[0]
-                content = content.replace('package://'+packageName, packagePath+'/'+packageName)
+                                    % packageName)
             else:
-                sys.stderr.write('Can\'t determine package root path.\n')
+                try:
+                    directory = get_package_share_directory(packageName)
+                except PackageNotFoundError:
+                    sys.stderr.write('Package "%s" not found.\n' % packageName)
+        if os.path.split(directory)[1]:
+            packagePath = os.path.split(directory)[0]
+            content = content.replace('package://'+packageName, packagePath+'/'+packageName)
+        else:
+            sys.stderr.write('Can\'t determine package root path.\n')
 
-        domFile = minidom.parseString(content)
-
-        for child in domFile.childNodes:
-            if child.localName == 'robot':
-                if isProto:
-                    if outFile:
-                        if os.path.splitext(os.path.basename(outFile))[1] == '.proto':
-                            robotName = os.path.splitext(os.path.basename(outFile))[0]
-                            outputFile = outFile
-                        else:
-                            # treat outFile as directory and construct filename
-                            robotName = convertLUtoUN(urdf2webots.parserURDF.getRobotName(child))  # capitalize
-                            outputFile = os.path.join(outFile, robotName + '.proto')
+    # Convert the content into Webots robot
+    domFile = minidom.parseString(content)
+    for child in domFile.childNodes:
+        if child.localName == 'robot':
+            if isProto:
+                if outFile:
+                    if os.path.splitext(os.path.basename(outFile))[1] == '.proto':
+                        robotName = os.path.splitext(os.path.basename(outFile))[0]
+                        outputFile = outFile
                     else:
+                        # treat outFile as directory and construct filename
                         robotName = convertLUtoUN(urdf2webots.parserURDF.getRobotName(child))  # capitalize
-                        outputFile = outFile if outFile else robotName + '.proto'
-
-                    mkdirSafe(outputFile.replace('.proto', '') + '_textures')  # make a dir called 'x_textures'
-
-                    if enableMultiFile:
-                        mkdirSafe(outputFile.replace('.proto', '') + '_meshes')  # make a dir called 'x_meshes'
-                        urdf2webots.writeRobot.meshFilesPath = outputFile.replace('.proto', '') + '_meshes'
-
-                    protoFile = open(outputFile, 'w')
-                    urdf2webots.writeRobot.header(protoFile, inFile, robotName)
+                        outputFile = os.path.join(outFile, robotName + '.proto')
                 else:
-                    tmp_robot_file = tempfile.NamedTemporaryFile(mode="w+", prefix='tempRobotURDFStringWebots')
+                    robotName = convertLUtoUN(urdf2webots.parserURDF.getRobotName(child))  # capitalize
+                    outputFile = outFile if outFile else robotName + '.proto'
 
-                urdf2webots.writeRobot.robotName = robotName
-                urdf2webots.parserURDF.robotName = robotName  # pass robotName
+                mkdirSafe(outputFile.replace('.proto', '') + '_textures')  # make a dir called 'x_textures'
 
-                robot = child
-                linkElementList = []
-                jointElementList = []
-                for child in robot.childNodes:
-                    if child.localName == 'link':
-                        linkElementList.append(child)
-                    elif child.localName == 'joint':
-                        jointElementList.append(child)
-                    elif child.localName == 'material':
-                        if not child.hasAttribute('name') \
-                           or child.getAttribute('name') not in urdf2webots.parserURDF.Material.namedMaterial:
-                            material = urdf2webots.parserURDF.Material()
-                            material.parseFromMaterialNode(child)
+                if enableMultiFile:
+                    mkdirSafe(outputFile.replace('.proto', '') + '_meshes')  # make a dir called 'x_meshes'
+                    urdf2webots.writeRobot.meshFilesPath = outputFile.replace('.proto', '') + '_meshes'
 
-                linkList = []
-                jointList = []
-                parentList = []
-                childList = []
-                rootLink = urdf2webots.parserURDF.Link()
+                protoFile = open(outputFile, 'w')
+                urdf2webots.writeRobot.header(protoFile, inputFile, robotName)
+            else:
+                tmp_robot_file = tempfile.NamedTemporaryFile(mode="w+", prefix='tempRobotURDFStringWebots')
 
-                for link in linkElementList:
-                    linkList.append(urdf2webots.parserURDF.getLink(link, inPath))
-                for joint in jointElementList:
-                    jointList.append(urdf2webots.parserURDF.getJoint(joint))
-                if not isProto:
-                    urdf2webots.parserURDF.removeDummyLinks(linkList, jointList)
+            urdf2webots.writeRobot.robotName = robotName
+            urdf2webots.parserURDF.robotName = robotName  # pass robotName
 
-                for joint in jointList:
-                    parentList.append(joint.parent)
-                    childList.append(joint.child)
-                parentList.sort()
-                childList.sort()
-                for link in linkList:
-                    if urdf2webots.parserURDF.isRootLink(link.name, childList):
-                        # We want to skip links between the robot and the static environment.
-                        rootLink = link
-                        previousRootLink = link
-                        while rootLink in ['base_link', 'base_footprint']:
-                            directJoints = []
-                            for joint in jointList:
-                                if joint.parent == rootLink.name:
-                                    directJoints.append(joint)
-                            if len(directJoints) == 1:
-                                for childLink in linkList:
-                                    if childLink.name == directJoints[0].child:
-                                        previousRootLink = rootLink
-                                        rootLink = childLink
-                            else:
-                                rootLink = previousRootLink
-                                break
+            robot = child
+            linkElementList = []
+            jointElementList = []
+            for child in robot.childNodes:
+                if child.localName == 'link':
+                    linkElementList.append(child)
+                elif child.localName == 'joint':
+                    jointElementList.append(child)
+                elif child.localName == 'material':
+                    if not child.hasAttribute('name') \
+                        or child.getAttribute('name') not in urdf2webots.parserURDF.Material.namedMaterial:
+                        material = urdf2webots.parserURDF.Material()
+                        material.parseFromMaterialNode(child)
 
-                        print('Root link: ' + rootLink.name)
-                        break
+            linkList = []
+            jointList = []
+            parentList = []
+            childList = []
+            rootLink = urdf2webots.parserURDF.Link()
 
-                for child in robot.childNodes:
-                    if child.localName == 'gazebo':
-                        urdf2webots.parserURDF.parseGazeboElement(child, rootLink.name, linkList)
+            for link in linkElementList:
+                linkList.append(urdf2webots.parserURDF.getLink(link, inPath))
+            for joint in jointElementList:
+                jointList.append(urdf2webots.parserURDF.getJoint(joint))
+            if not isProto:
+                urdf2webots.parserURDF.removeDummyLinks(linkList, jointList)
 
-                sensorList = (urdf2webots.parserURDF.IMU.list +
-                              urdf2webots.parserURDF.P3D.list +
-                              urdf2webots.parserURDF.Camera.list +
-                              urdf2webots.parserURDF.Lidar.list)
-                print('There are %d links, %d joints and %d sensors' % (len(linkList), len(jointList), len(sensorList)))
+            for joint in jointList:
+                parentList.append(joint.parent)
+                childList.append(joint.child)
+            parentList.sort()
+            childList.sort()
+            for link in linkList:
+                if urdf2webots.parserURDF.isRootLink(link.name, childList):
+                    # We want to skip links between the robot and the static environment.
+                    rootLink = link
+                    previousRootLink = link
+                    while rootLink in ['base_link', 'base_footprint']:
+                        directJoints = []
+                        for joint in jointList:
+                            if joint.parent == rootLink.name:
+                                directJoints.append(joint)
+                        if len(directJoints) == 1:
+                            for childLink in linkList:
+                                if childLink.name == directJoints[0].child:
+                                    previousRootLink = rootLink
+                                    rootLink = childLink
+                        else:
+                            rootLink = previousRootLink
+                            break
 
-                if isProto:
-                    urdf2webots.writeRobot.declaration(protoFile, robotName, initTranslation, initRotation)
-                    urdf2webots.writeRobot.URDFLink(protoFile, rootLink, 1, parentList, childList, linkList, jointList,
-                                                    sensorList, boxCollision=boxCollision, normal=normal, robot=True)
-                    protoFile.write('}\n')
-                    protoFile.close()
-                    return
-                else:
-                    urdf2webots.writeRobot.URDFLink(tmp_robot_file, rootLink, 0, parentList,
-                                childList, linkList, jointList, sensorList, boxCollision=boxCollision,
-                                normal=normal, robot=True, initTranslation=initTranslation, initRotation=initRotation)
+                    print('Root link: ' + rootLink.name)
+                    break
 
-                    tmp_robot_file.seek(0)
-                    return (tmp_robot_file.read())
-    print('Could not read file')
+            for child in robot.childNodes:
+                if child.localName == 'gazebo':
+                    urdf2webots.parserURDF.parseGazeboElement(child, rootLink.name, linkList)
+
+            sensorList = (urdf2webots.parserURDF.IMU.list +
+                            urdf2webots.parserURDF.P3D.list +
+                            urdf2webots.parserURDF.Camera.list +
+                            urdf2webots.parserURDF.Lidar.list)
+            print('There are %d links, %d joints and %d sensors' % (len(linkList), len(jointList), len(sensorList)))
+
+            if isProto:
+                urdf2webots.writeRobot.declaration(protoFile, robotName, initTranslation, initRotation)
+                urdf2webots.writeRobot.URDFLink(protoFile, rootLink, 1, parentList, childList, linkList, jointList,
+                                                sensorList, boxCollision=boxCollision, normal=normal, robot=True)
+                protoFile.write('}\n')
+                protoFile.close()
+                return
+            else:
+                urdf2webots.writeRobot.URDFLink(tmp_robot_file, rootLink, 0, parentList,
+                            childList, linkList, jointList, sensorList, boxCollision=boxCollision,
+                            normal=normal, robot=True, initTranslation=initTranslation, initRotation=initRotation)
+
+                tmp_robot_file.seek(0)
+                return (tmp_robot_file.read())
+    sys.exit('Could not parse the URDF file.\n')
 
 
 if __name__ == '__main__':
     optParser = optparse.OptionParser(usage='usage: %prog --input=my_robot.urdf [options]')
-    optParser.add_option('--input', dest='inFile', default='', help='Specifies the urdf file to convert.')
+    optParser.add_option('--input', dest='input', default='', help='Specifies the URDF file or the URDF content string to convert.')
     optParser.add_option('--output', dest='outFile', default='', help='Specifies the path and, if ending in ".proto", name '
                          'of the resulting PROTO file. The filename minus the .proto extension will be the robot name (for PROTO conversion only).')
     optParser.add_option('--robot-name', dest='robotName', default=None, help='Specifies the name of the robot '
@@ -250,7 +278,7 @@ if __name__ == '__main__':
     optParser.add_option('--multi-file', dest='enableMultiFile', action='store_true', default=False,
                          help='If set, the mesh files are exported as separated PROTO files.')
     optParser.add_option('--tool-slot', dest='toolSlot', default=None,
-                         help='Specify the link that you want to add a tool slot too (exact link name from urdf, for PROTO conversion only).')
+                         help='Specify the link that you want to add a tool slot too (exact link name from URDF, for PROTO conversion only).')
     optParser.add_option('--translation', dest='initTranslation', default='0 0 0',
                          help='Set the translation field of your PROTO file or Webots VRML robot string.')
     optParser.add_option('--rotation', dest='initRotation', default='0 0 1 0',
@@ -260,9 +288,9 @@ if __name__ == '__main__':
                          'set the first 3 joints of your robot to the specified values, and leave the rest with their '
                          'default value.')
     optParser.add_option('--link-to-def', dest='linkToDef', action='store_true', default=False,
-                         help='If set, urdf link names are also used as DEF names as well as solid names.')
+                         help='Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).')
     optParser.add_option('--joint-to-def', dest='jointToDef', action='store_true', default=False,
-                         help='If set, urdf joint names are also used as DEF names as well as joint names.')
+                         help='Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).')
     options, args = optParser.parse_args()
     convert2urdf(options.inFile, options.outFile, options.robotName, options.normal, options.boxCollision, options.disableMeshOptimization,
                  options.enableMultiFile, options.toolSlot, options.initTranslation, options.initRotation, options.initPos, options.linkToDef, options.jointToDef)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -62,7 +62,6 @@ def convertUrdfFile(input = None, output=None, robotName=None, normal=False, box
     urdfContent = None
     if not input:
         print('''"--input" not specified, a URDF content will be read in the in stdin.\n
-            You might copy-past your URDF content in the terminal.\n
             The "</robot>" tag will stop the lecture.''')
         urdfContent = ""
         for line in sys.stdin:
@@ -99,15 +98,15 @@ def convertUrdfContent(input, output=None, robotName=None, normal=False, boxColl
                  initPos=None, linkToDef=False, jointToDef=False):
     """
     Convert a URDF content string into a Webots PROTO file or Robot node string.
-    Relative paths to your URDF file will not work, but "package://" and "webots://" paths will work.
-    If you have relative paths in your URDF file, please use the convertUrdfFile() function.
+    The current working directory will be used for relative paths in your URDF file.
+    To use the location of your URDF file for relative paths, please use the convertUrdfFile() function.
     """
     # Retrieve urdfPath if this function has been called from convertUrdfFile()
     if convertUrdfFile.urdfPath is not None:
         urdfPath = convertUrdfFile.urdfPath
         convertUrdfFile.urdfPath = None
     else:
-        urdfPath = ""
+        urdfPath = os.getcwd()
 
     if not type(initTranslation) == str or len(initTranslation.split()) != 3:
         sys.exit('--translation argument is not valid. It has to be of Type = str and contain 3 values.')

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -128,21 +128,21 @@ def convert2urdf(input, outFile=None, robotName=None, normal=False, boxCollision
         while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
             directory = os.path.dirname(directory)
         if not os.path.split(directory)[1]:
-            if 'ROS_VERSION' in os.environ and os.environ['ROS_VERSION'] == '1':
-                try:
-                    rospack = rospkg.RosPack()
-                    print(str(rospack.list()))
-                    directory = rospack.get_path(packageName)
-                except rospkg.common.ResourceNotFound:
-                    sys.stderr.write('Package "%s" not found.\n' % packageName)
-                except NameError:
-                    sys.stderr.write('Impossible to find location of "%s" package, installing "rospkg" might help.\n'
-                                    % packageName)
-            else:
-                try:
-                    directory = get_package_share_directory(packageName)
-                except PackageNotFoundError:
-                    sys.stderr.write('Package "%s" not found.\n' % packageName)
+            if 'ROS_VERSION' in os.environ:
+                if os.environ['ROS_VERSION'] == '1':
+                    try:
+                        rospack = rospkg.RosPack()
+                        directory = rospack.get_path(packageName)
+                    except rospkg.common.ResourceNotFound:
+                        sys.stderr.write('Package "%s" not found.\n' % packageName)
+                    except NameError:
+                        sys.stderr.write('Impossible to find location of "%s" package, installing "rospkg" might help.\n'
+                                        % packageName)
+                else:
+                    try:
+                        directory = get_package_share_directory(packageName)
+                    except PackageNotFoundError:
+                        sys.stderr.write('Package "%s" not found.\n' % packageName)
         if os.path.split(directory)[1]:
             packagePath = os.path.split(directory)[0]
             content = content.replace('package://'+packageName, packagePath+'/'+packageName)
@@ -292,5 +292,5 @@ if __name__ == '__main__':
     optParser.add_option('--joint-to-def', dest='jointToDef', action='store_true', default=False,
                          help='Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).')
     options, args = optParser.parse_args()
-    convert2urdf(options.inFile, options.outFile, options.robotName, options.normal, options.boxCollision, options.disableMeshOptimization,
+    convert2urdf(options.input, options.outFile, options.robotName, options.normal, options.boxCollision, options.disableMeshOptimization,
                  options.enableMultiFile, options.toolSlot, options.initTranslation, options.initRotation, options.initPos, options.linkToDef, options.jointToDef)

--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -50,7 +50,10 @@ def header(robotFile, srcFile=None, protoName=None, tags=[]):
     if protoName:
         robotFile.write('# This is a proto file for Webots for the ' + protoName + '\n')
     if srcFile:
-        robotFile.write('# Extracted from: ' + srcFile + '\n\n')
+        robotFile.write('# Extracted from: ' + srcFile + '\n')
+    else:
+        robotFile.write('# Extracted from a URDF content string\n')
+    robotFile.write('\n')
 
 
 def declaration(robotFile, robotName, initTranslation, initRotation):


### PR DESCRIPTION
A standard way to use URDF files in ROS 2 launch file is to give the content of the URDF to nodes, rather than giving them the path to the URDF file.

Additionally a user might want to convert his Xacro file and will get the content of an URDF file as result. It would not be handy to force him to create a temporary file in order to give a path to the conversion tool.

Linked to https://github.com/cyberbotics/webots_ros2/pull/345.