### PR TITLE
Add relative paths prefix when converting from URDF content

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ The script accepts the following arguments:
   - **--init-pos=JointPositions**: Set the initial positions of your robot joints. Example: `--init-pos="[1.2, 0.5, -1.5]"` would set the first 3 joints of your robot to the specified values, and leave the rest with their default value.
   - **--link-to-def**: Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
   - **--joint-to-def**: Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
+  - **--relative-path-prefix**: If set and **--input** not specified, relative paths present in your URDF file will get this prefix. Example: `filename="head.obj"` with `--relative-path-prefix="/home/user/myRobot/"` will became `filename="/home/user/myRobot/head.obj"`.
 
 In case the **--input** option is missing, the script will read the URDF content from `stdin`.
 In that case, you can pipe the content of your URDF file into the script: `cat my_robot.urdf | urdf2proto.py`.
-Relative paths present in your URDF file will be treated relatively to the current directory from which the script is called.
+Relative paths present in your URDF file will be treated relatively to the current directory from which the script is called unless **--relative-path-prefix** is set.
 
 > Previously the **--static-base** argument was supported in order to set the base link to be static (disabled physics). It has been removed as there is a better way to do it by adding the following to your URDF file (assuming **base_link** is the root link of your robot):
 >
@@ -80,6 +81,7 @@ The command line arguments available from the terminal are also available from t
 | --init-pos |  initPos |
 | --link-to-def |  linkToDef |
 | --joint-to-def |  jointToDef |
+| --relative-path-prefix |  relativePathPrefix |
 
 In Python, you can convert a URDF file by passing its path as an argument to the `convertUrdfFile()` function or directly by passing its content as an argument to the `convertUrdfContent()` function.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The script accepts the following arguments:
   - **--init-pos=JointPositions**: Set the initial positions of your robot joints. Example: `--init-pos="[1.2, 0.5, -1.5]"` would set the first 3 joints of your robot to the specified values, and leave the rest with their default value.
   - **--link-to-def**: Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
   - **--joint-to-def**: Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).
-  - **--relative-path-prefix**: If set and **--input** not specified, relative paths present in your URDF file will get this prefix. Example: `filename="head.obj"` with `--relative-path-prefix="/home/user/myRobot/"` will became `filename="/home/user/myRobot/head.obj"`.
+  - **--relative-path-prefix**: If **--input** is not set, the relative paths in your URDF file sent through stdin will use this prefix. For example: `filename="head.obj"` with `--relative-path-prefix="/home/user/myRobot/"` will become `filename="/home/user/myRobot/head.obj"`.
 
 In case the **--input** option is missing, the script will read the URDF content from `stdin`.
 In that case, you can pipe the content of your URDF file into the script: `cat my_robot.urdf | urdf2proto.py`.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='urdf2webots',
-    version='1.0.15',
+    version='1.0.16',
     author='Cyberbotics',
     author_email='support@cyberbotics.com',
     description='A converter between URDF and PROTO files.',

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -58,7 +58,7 @@ modelPathsRobotString = [
 ]
 
 
-def fileCompare(file1, file2, checkPaths=True):
+def fileCompare(file1, file2):
     """Compare content of two files."""
     with open(file1) as f1, open(file2) as f2:
         for i, (line1, line2) in enumerate(zip(f1, f2)):
@@ -68,7 +68,7 @@ def fileCompare(file1, file2, checkPaths=True):
             elif line1.startswith('#VRML_SIM') and line2.startswith('#VRML_SIM'):
                 # This line may differ according to Webots version used
                 continue
-            elif not checkPaths or ('CI' not in os.environ and '/home/runner/work/' in line2):
+            elif 'CI' not in os.environ and '/home/runner/work/' in line2:
                 # When testing locally, the paths may differ.
                 continue
             elif line1 != line2:
@@ -105,7 +105,7 @@ class TestScript(unittest.TestCase):
         for paths in modelContentProto:
             convertUrdfContent(input=paths['input'], output=paths['output'], relativePathPrefix=paths['relativePathPrefix'])
             for expected in paths['expected']:
-                self.assertTrue(fileCompare(expected.replace('expected', 'results'), expected, checkPaths=True),
+                self.assertTrue(fileCompare(expected.replace('expected', 'results'), expected),
                                 msg='Expected result mismatch when exporting input to "%s"' % paths['output'])
 
     def testInputContentStdinOutputProto(self):
@@ -115,7 +115,7 @@ class TestScript(unittest.TestCase):
             sys.stdin = io.StringIO(paths['input'])
             convertUrdfFile(output=paths['output'], relativePathPrefix=paths['relativePathPrefix'])
             for expected in paths['expected']:
-                self.assertTrue(fileCompare(expected.replace('expected', 'results'), expected, checkPaths=True),
+                self.assertTrue(fileCompare(expected.replace('expected', 'results'), expected),
                                 msg='Expected result mismatch when exporting input to "%s"' % paths['output'])
 
     def testInputFileOutputRobotString(self):
@@ -123,7 +123,7 @@ class TestScript(unittest.TestCase):
         print('Start tests with input "URDF file" and output "Robot node strings"...')
         for paths in modelPathsRobotString:
             robot_string = convertUrdfFile(input=paths['input'], robotName=paths['robotName'], initTranslation=paths['translation'], initRotation=paths['rotation'])
-            f = open(paths['output'], 'a+')
+            f = open(paths['output'], 'w')
             f.write(robot_string)
             f.close()
             for expected in paths['expected']:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -42,7 +42,7 @@ modelContentProto = [
         'input': pathlib.Path(human_file_path).read_text(),
         'output': os.path.join(resultDirectory, 'Human.proto'),
         'expected': [os.path.join(expectedDirectory, 'Human.proto')],
-        'arguments': ''
+        'relativePathPrefix': '/home/runner/work/urdf2webots/urdf2webots/tests/sources/gait2392_simbody/urdf',
     }
 ]
 
@@ -103,9 +103,9 @@ class TestScript(unittest.TestCase):
         """Test that urdf2webots produces an expected PROTO file using URDF content as input."""
         print('Start tests with input "URDF content" and output "PROTO file"...')
         for paths in modelContentProto:
-            convertUrdfContent(input=paths['input'], output=paths['output'])
+            convertUrdfContent(input=paths['input'], output=paths['output'], relativePathPrefix=paths['relativePathPrefix'])
             for expected in paths['expected']:
-                self.assertTrue(fileCompare(expected.replace('expected', 'results'), expected, checkPaths=False),
+                self.assertTrue(fileCompare(expected.replace('expected', 'results'), expected, checkPaths=True),
                                 msg='Expected result mismatch when exporting input to "%s"' % paths['output'])
 
     def testInputContentStdinOutputProto(self):
@@ -113,9 +113,9 @@ class TestScript(unittest.TestCase):
         print('Start tests with input "URDF content" and output "PROTO file"...')
         for paths in modelContentProto:
             sys.stdin = io.StringIO(paths['input'])
-            convertUrdfFile(output=paths['output'])
+            convertUrdfFile(output=paths['output'], relativePathPrefix=paths['relativePathPrefix'])
             for expected in paths['expected']:
-                self.assertTrue(fileCompare(expected.replace('expected', 'results'), expected, checkPaths=False),
+                self.assertTrue(fileCompare(expected.replace('expected', 'results'), expected, checkPaths=True),
                                 msg='Expected result mismatch when exporting input to "%s"' % paths['output'])
 
     def testInputFileOutputRobotString(self):
@@ -123,7 +123,7 @@ class TestScript(unittest.TestCase):
         print('Start tests with input "URDF file" and output "Robot node strings"...')
         for paths in modelPathsRobotString:
             robot_string = convertUrdfFile(input=paths['input'], robotName=paths['robotName'], initTranslation=paths['translation'], initRotation=paths['rotation'])
-            f = open(paths['output'], 'w')
+            f = open(paths['output'], 'a+')
             f.write(robot_string)
             f.close()
             for expected in paths['expected']:

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -327,8 +327,8 @@ if __name__ == '__main__':
                          help='Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) '
                          '(for PROTO conversion only).')
     optParser.add_option('--relative-path-prefix', dest='relativePathPrefix', default=None,
-                         help='If set and --input not specified, relative paths present in your URDF file will be treated relatively to it '
-                         'rather than relative to the current directory from which the script is called.')
+                         help='If set and --input not specified, relative paths in your URDF file will be treated relatively to it '
+                         'rather than relatively to the current directory from which the script is called.')
     options, args = optParser.parse_args()
     convertUrdfFile(options.input, options.output, options.robotName, options.normal, options.boxCollision, options.disableMeshOptimization,
                  options.enableMultiFile, options.toolSlot, options.initTranslation, options.initRotation, options.initPos, options.linkToDef, options.jointToDef, options.relativePathPrefix)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import tempfile
+from tkinter.messagebox import NO
 from xml.dom import minidom
 
 import urdf2webots.parserURDF
@@ -54,10 +55,10 @@ def mkdirSafe(directory):
             print('Directory "' + directory + '" already exists!')
 
 
-def convertUrdfFile(input = None, output=None, robotName=None, normal=False, boxCollision=False,
+def convertUrdfFile(input=None, output=None, robotName=None, normal=False, boxCollision=False,
                  disableMeshOptimization=False, enableMultiFile=False,
                  toolSlot=None, initTranslation='0 0 0', initRotation='0 0 1 0',
-                 initPos=None, linkToDef=False, jointToDef=False):
+                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None):
     """Convert a URDF file into a Webots PROTO file or Robot node string."""
     urdfContent = None
     if not input:
@@ -86,7 +87,7 @@ def convertUrdfFile(input = None, output=None, robotName=None, normal=False, box
     return convertUrdfContent(urdfContent, output, robotName, normal, boxCollision,
                  disableMeshOptimization, enableMultiFile,
                  toolSlot, initTranslation, initRotation,
-                 initPos, linkToDef, jointToDef)
+                 initPos, linkToDef, jointToDef, relativePathPrefix)
 
 
 convertUrdfFile.urdfPath = None
@@ -95,18 +96,23 @@ convertUrdfFile.urdfPath = None
 def convertUrdfContent(input, output=None, robotName=None, normal=False, boxCollision=False,
                  disableMeshOptimization=False, enableMultiFile=False,
                  toolSlot=None, initTranslation='0 0 0', initRotation='0 0 1 0',
-                 initPos=None, linkToDef=False, jointToDef=False):
+                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None):
     """
     Convert a URDF content string into a Webots PROTO file or Robot node string.
     The current working directory will be used for relative paths in your URDF file.
     To use the location of your URDF file for relative paths, please use the convertUrdfFile() function.
     """
     # Retrieve urdfPath if this function has been called from convertUrdfFile()
+    # And set urdfDirectory accordingly
+    urdfPath = None
     if convertUrdfFile.urdfPath is not None:
         urdfPath = convertUrdfFile.urdfPath
+        urdfDirectory = os.path.dirname(urdfPath)
         convertUrdfFile.urdfPath = None
+    elif relativePathPrefix is not None:
+        urdfDirectory = relativePathPrefix
     else:
-        urdfPath = os.getcwd()
+        urdfDirectory = os.getcwd()
 
     if not type(initTranslation) == str or len(initTranslation.split()) != 3:
         sys.exit('--translation argument is not valid. It has to be of Type = str and contain 3 values.')
@@ -149,7 +155,7 @@ def convertUrdfContent(input, output=None, robotName=None, normal=False, boxColl
     # Replace "package://(.*)" occurences
     for match in re.finditer('"package://(.*)"', input):
         packageName = match.group(1).split('/')[0]
-        directory = os.path.dirname(urdfPath)
+        directory = urdfDirectory
         while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:
             directory = os.path.dirname(directory)
         if not os.path.split(directory)[1]:
@@ -228,7 +234,7 @@ def convertUrdfContent(input, output=None, robotName=None, normal=False, boxColl
             rootLink = urdf2webots.parserURDF.Link()
 
             for link in linkElementList:
-                linkList.append(urdf2webots.parserURDF.getLink(link, os.path.dirname(urdfPath)))
+                linkList.append(urdf2webots.parserURDF.getLink(link, urdfDirectory))
             for joint in jointElementList:
                 jointList.append(urdf2webots.parserURDF.getJoint(joint))
             if not isProto:
@@ -292,7 +298,8 @@ if __name__ == '__main__':
     optParser = optparse.OptionParser(usage='usage: %prog --input=my_robot.urdf [options]')
     optParser.add_option('--input', dest='input', default='', help='Specifies the URDF file.')
     optParser.add_option('--output', dest='output', default='', help='Specifies the path and, if ending in ".proto", name '
-                         'of the resulting PROTO file. The filename minus the .proto extension will be the robot name (for PROTO conversion only).')
+                         'of the resulting PROTO file. The filename minus the .proto extension will be the robot name '
+                         '(for PROTO conversion only).')
     optParser.add_option('--robot-name', dest='robotName', default=None, help='Specifies the name of the robot '
                          'and generate a Robot node string instead of a PROTO file (has to be unique).')
     optParser.add_option('--normal', dest='normal', action='store_true', default=False,
@@ -315,9 +322,14 @@ if __name__ == '__main__':
                          'set the first 3 joints of your robot to the specified values, and leave the rest with their '
                          'default value.')
     optParser.add_option('--link-to-def', dest='linkToDef', action='store_true', default=False,
-                         help='Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).')
+                         help='Creates a DEF with the link name for each solid to be able to access it using getFromProtoDef(defName) '
+                         '(for PROTO conversion only).')
     optParser.add_option('--joint-to-def', dest='jointToDef', action='store_true', default=False,
-                         help='Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) (for PROTO conversion only).')
+                         help='Creates a DEF with the joint name for each joint to be able to access it using getFromProtoDef(defName) '
+                         '(for PROTO conversion only).')
+    optParser.add_option('--relative-path-prefix', dest='relativePathPrefix', default=None,
+                         help='If set and --input not specified, relative paths present in your URDF file will be treated relatively to it '
+                         'rather than relative to the current directory from which the script is called.')
     options, args = optParser.parse_args()
     convertUrdfFile(options.input, options.output, options.robotName, options.normal, options.boxCollision, options.disableMeshOptimization,
-                 options.enableMultiFile, options.toolSlot, options.initTranslation, options.initRotation, options.initPos, options.linkToDef, options.jointToDef)
+                 options.enableMultiFile, options.toolSlot, options.initTranslation, options.initRotation, options.initPos, options.linkToDef, options.jointToDef, options.relativePathPrefix)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -9,7 +9,6 @@ import os
 import re
 import sys
 import tempfile
-from tkinter.messagebox import NO
 from xml.dom import minidom
 
 import urdf2webots.parserURDF
@@ -153,7 +152,7 @@ def convertUrdfContent(input, output=None, robotName=None, normal=False, boxColl
     urdf2webots.parserURDF.Geometry.reference.clear()
 
     # Replace "package://(.*)" occurences
-    for match in re.finditer('"package://(.*)"', input):
+    for match in re.finditer('"package://(.*?)"', input):
         packageName = match.group(1).split('/')[0]
         directory = urdfDirectory
         while packageName != os.path.split(directory)[1] and os.path.split(directory)[1]:


### PR DESCRIPTION
As the ROS 2 URDF importer can import URDF content, getting the current directory to as origin for relative paths will not work.