### PR TITLE
Parse clip element from gazebo and add it as near element in proto

### DIFF
--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -883,8 +883,11 @@ def parseGazeboElement(element, parentLink, linkList):
                         if lidar.maxRange:
                             lidar.noise /= lidar.maxRange
                 # minRange and near default values are 0.01 in Webots; ensure constraint near <= minRange
-                if not lidar.near and lidar.minRange < 0.01:
+                if lidar.near and lidar.minRange and lidar.near > lidar.minRange:
+                    lidar.minRange = lidar.near
+                    print('The "minRange" value cannot be strictly inferior to the "near" value for a lidar, "minRange" has been set to the value of "near".')
+                elif not lidar.near and lidar.minRange < 0.01:
                     lidar.near = lidar.minRange
-                if not lidar.minRange and lidar.near > 0.01:
+                elif not lidar.minRange and lidar.near > 0.01:
                     lidar.minRange = lidar.near
             Lidar.list.append(lidar)

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -382,10 +382,7 @@ class Lidar():
         if self.numberOfLayers:
             file.write(indentationLevel * indent + '  numberOfLayers %d\n' % self.numberOfLayers)
         if self.minRange:
-            if self.near and self.minRange < self.near:
-                file.write(indentationLevel * indent + '  minRange %lf\n' % self.near)
-            else:
-                file.write(indentationLevel * indent + '  minRange %lf\n' % self.minRange)
+            file.write(indentationLevel * indent + '  minRange %lf\n' % self.minRange)
         if self.maxRange:
             file.write(indentationLevel * indent + '  maxRange %lf\n' % self.maxRange)
         if self.noise:
@@ -885,4 +882,9 @@ def parseGazeboElement(element, parentLink, linkList):
                         lidar.noise = float(noiseElement.getElementsByTagName('stddev')[0].firstChild.nodeValue)
                         if lidar.maxRange:
                             lidar.noise /= lidar.maxRange
+                # minRange and near default values are 0.01 in Webots; ensure constraint near <= minRange
+                if not lidar.near and lidar.minRange < 0.01:
+                    lidar.near = lidar.minRange
+                if not lidar.minRange and lidar.near > 0.01:
+                    lidar.minRange = lidar.near
             Lidar.list.append(lidar)

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -366,6 +366,7 @@ class Lidar():
         self.maxRange = None
         self.resolution = None
         self.noise = None
+        self.near = None
 
     def export(self, file, indentationLevel):
         """Export this lidar."""
@@ -381,15 +382,18 @@ class Lidar():
         if self.numberOfLayers:
             file.write(indentationLevel * indent + '  numberOfLayers %d\n' % self.numberOfLayers)
         if self.minRange:
-            if self.minRange < 0.01:
-                file.write(indentationLevel * indent + '  near %lf\n' % self.minRange)
-            file.write(indentationLevel * indent + '  minRange %lf\n' % self.minRange)
+            if self.near and self.minRange < self.near:
+                file.write(indentationLevel * indent + '  minRange %lf\n' % self.near)
+            else:
+                file.write(indentationLevel * indent + '  minRange %lf\n' % self.minRange)
         if self.maxRange:
             file.write(indentationLevel * indent + '  maxRange %lf\n' % self.maxRange)
         if self.noise:
             file.write(indentationLevel * indent + '  noise %lf\n' % self.noise)
         if self.resolution:
             file.write(indentationLevel * indent + '  resolution %lf\n' % self.resolution)
+        if self.near:
+            file.write(indentationLevel * indent + '  near %lf\n' % self.near)
         file.write(indentationLevel * indent + '}\n')
 
 
@@ -863,6 +867,10 @@ def parseGazeboElement(element, parentLink, linkList):
                             minAngle = float(verticalElement.getElementsByTagName('min_angle')[0].firstChild.nodeValue)
                             maxAngle = float(verticalElement.getElementsByTagName('max_angle')[0].firstChild.nodeValue)
                             lidar.verticalFieldOfView = maxAngle - minAngle
+                if hasElement(rayElement, 'clip'):
+                    clipElement = rayElement.getElementsByTagName('clip')[0]
+                    if hasElement(clipElement, 'near'):
+                        lidar.near = float(clipElement.getElementsByTagName('near')[0].firstChild.nodeValue)
                 if hasElement(rayElement, 'range'):
                     rangeElement = rayElement.getElementsByTagName('range')[0]
                     if hasElement(rangeElement, 'min'):


### PR DESCRIPTION
Parsing the clip field from the URDF and add it to the lidar node as "near" property. This change makes the lidar respect minimal sense range as defined by the URDF.