### PR TITLE
Imaging device requires additional transform as Webots uses different coordinate system for cameras

### DIFF
--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -348,6 +348,7 @@ class Camera():
         self.width = None
         self.height = None
         self.noise = None
+        self.isImager = True
 
     def export(self, file, indentationLevel):
         """Export this camera."""

--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -131,7 +131,16 @@ def URDFLink(robotFile, link, level, parentList,
                 if not haveChild:
                     haveChild = True
                     robotFile.write((level + 1) * indent + 'children [\n')
-                sensor.export(robotFile, level + 2)
+                if hasattr(sensor, 'isImager') and sensor.isImager:
+                    robotFile.write((level + 2) * indent + 'Transform {\n')
+                    robotFile.write((level + 3) * indent + 'translation 0 0 0\n')
+                    robotFile.write((level + 3) * indent + 'rotation 0.577350 -0.577350 0.577350 2.094395\n')
+                    robotFile.write((level + 3) * indent + 'children [\n')
+                    sensor.export(robotFile, level + 4)
+                    robotFile.write((level + 3) * indent + ']\n')
+                    robotFile.write((level + 2) * indent + '}\n')
+                else:
+                    sensor.export(robotFile, level + 2)
         # 3: export Joints
         for joint in jointList:
             if joint.parent == link.name:


### PR DESCRIPTION
[Webots](https://cyberbotics.com/doc/reference/camera) defines the camera frame differently as [ROS](http://wiki.ros.org/image_pipeline/CameraInfo). This patch applies the required transform when the sensor is tagged as "imager".

Note: This patch is required for #161 
