### PR TITLE
Fix loss of physics

### DIFF
--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -892,8 +892,13 @@ def removeDummyLinksAndStaticBaseFlag(linkList, jointList, toolSlot):
                     jointList.remove(jointList[childJointIndex])
                 else:
                     # Special case for dummy non-root links used to fix the base of the robot
-                    if isRootLink(jointList[parentJointIndex].parent, childList):
-                        staticBase = True
+                    parentLink = jointList[parentJointIndex].parent
+                    if isRootLink(parentLink, childList):
+                        # Ensure the parent link does not have physics, if it does, it should be kept as-is
+                        # since some sensors require the parent to have physics
+                        for l in linkList:
+                            if l.name is parentLink and l.inertia.mass is None:
+                                staticBase = True
 
                     jointList.remove(jointList[parentJointIndex])
 


### PR DESCRIPTION
**Description**
Fixes https://github.com/cyberbotics/urdf2webots/issues/168.

The reason it appears to be working in develop but not in master is because the bug was introduced in this PR https://github.com/cyberbotics/urdf2webots/pull/165 which targeted master.
Basically, it seems that the aim was to collapse structures like `link1 -- j1 -- link2 -- j2 -- link3` down to `link1 -- j3 -- link3` if and only if link2 happened to be a mass-less dummy link. Issue https://github.com/cyberbotics/urdf2webots/issues/168 however arises from the fact that when one of the collapse candidates arises, we force the parent link to become static and therefore if it had physics, we end-up losing this information by making it static.

The proposed change does fix the issue, but I have to admit I don't really understand why we are forcing the parent to be static in the first place. From my understanding, the dummy link is an issue since we can't really have a non-physical node in-between two physically enabled ones, so removing it makes sense but then either:
- the parent (link1) does have physics: it should be kept or we might break stuff (for instance if the same node has sensor children which require the parent to have physics we can't remove it)
- the parent (link1) does not have physics: then the dummy not having it isn't really an issue since we are regardless in a staticbase scenario (although removing it makes the PROTO cleaner)

In short, I'm not sure to understand exactly which scenario does this approach is meant to address.