### PR TITLE
Set empty lookup table for force sensors to actually measure in Newton [N]

### DIFF
--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -103,6 +103,7 @@ def URDFLink(robotFile, link, level, parentList,
         if link.forceSensor:
             robotFile.write((' ' if endpoint else level * indent) + ('DEF ' + link.name + ' ' if linkToDef else '') + 'TouchSensor {\n')
             robotFile.write((level + 1) * indent + 'type "force-3d"\n')
+            robotFile.write((level + 1) * indent + 'lookupTable []\n')
         else:
             robotFile.write((' ' if endpoint else level * indent) + ('DEF ' + link.name + ' ' if linkToDef else '') + 'Solid {\n')
             if not isProto:


### PR DESCRIPTION
Set empty lookup table for force sensors to actually measure in Newton [N]. The default lookup table a) provides an inconvenient scaling and b) limits the sensor measurement range to [0 5000] (see: https://cyberbotics.com/doc/reference/touchsensor#lookup-table).