### PR TITLE
Feature optional `CadShape`

### DIFF
--- a/tests/expected/Human.proto
+++ b/tests/expected/Human.proto
@@ -1,4 +1,4 @@
-#VRML_SIM R2022a utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # This is a proto file for Webots for the Human

--- a/tests/expected/Human.proto
+++ b/tests/expected/Human.proto
@@ -152,7 +152,6 @@ PROTO Human [
                                   physics Physics {
                                     density -1
                                     mass 0.216600
-                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       1.000000e-04 2.000000e-04 1.000000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -168,7 +167,6 @@ PROTO Human [
                             physics Physics {
                               density -1
                               mass 1.250000
-                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 1.400000e-03 3.900000e-03 4.100000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -184,7 +182,6 @@ PROTO Human [
                       physics Physics {
                         density -1
                         mass 0.100000
-                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           1.000000e-03 1.000000e-03 1.000000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -200,7 +197,6 @@ PROTO Human [
                 physics Physics {
                   density -1
                   mass 3.707500
-                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     5.040000e-02 5.100000e-03 5.110000e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -216,7 +212,6 @@ PROTO Human [
           physics Physics {
             density -1
             mass 9.301400
-            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.339000e-01 3.510000e-02 1.412000e-01
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -349,7 +344,6 @@ PROTO Human [
                                   physics Physics {
                                     density -1
                                     mass 0.216600
-                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       1.000000e-04 2.000000e-04 1.000000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -371,7 +365,6 @@ PROTO Human [
                             physics Physics {
                               density -1
                               mass 1.250000
-                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 1.400000e-03 3.900000e-03 4.100000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -387,7 +380,6 @@ PROTO Human [
                       physics Physics {
                         density -1
                         mass 0.100000
-                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           1.000000e-03 1.000000e-03 1.000000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -403,7 +395,6 @@ PROTO Human [
                 physics Physics {
                   density -1
                   mass 3.707500
-                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     5.040000e-02 5.100000e-03 5.110000e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -419,7 +410,6 @@ PROTO Human [
           physics Physics {
             density -1
             mass 9.301400
-            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.339000e-01 3.510000e-02 1.412000e-01
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -550,7 +540,6 @@ PROTO Human [
                                   physics Physics {
                                     density -1
                                     mass 0.457500
-                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       8.920000e-04 5.470000e-04 1.340000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -566,7 +555,6 @@ PROTO Human [
                             physics Physics {
                               density -1
                               mass 0.607500
-                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 2.962000e-03 6.180000e-04 3.213000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -582,7 +570,6 @@ PROTO Human [
                       physics Physics {
                         density -1
                         mass 0.607500
-                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           2.962000e-03 6.180000e-04 3.213000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -598,7 +585,6 @@ PROTO Human [
                 physics Physics {
                   density -1
                   mass 2.032500
-                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     1.194600e-02 4.121000e-03 1.340900e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -706,7 +692,6 @@ PROTO Human [
                                   physics Physics {
                                     density -1
                                     mass 0.457500
-                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       8.920000e-04 5.470000e-04 1.340000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -722,7 +707,6 @@ PROTO Human [
                             physics Physics {
                               density -1
                               mass 0.607500
-                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 2.962000e-03 6.180000e-04 3.213000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -738,7 +722,6 @@ PROTO Human [
                       physics Physics {
                         density -1
                         mass 0.607500
-                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           2.962000e-03 6.180000e-04 3.213000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -754,7 +737,6 @@ PROTO Human [
                 physics Physics {
                   density -1
                   mass 2.032500
-                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     1.194600e-02 4.121000e-03 1.340900e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -770,7 +752,6 @@ PROTO Human [
           physics Physics {
             density -1
             mass 26.826600
-            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.474500e+00 7.555000e-01 1.431400e+00
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -786,7 +767,6 @@ PROTO Human [
     physics Physics {
       density -1
       mass 11.777000
-      centerOfMass [ 0.000000 0.000000 0.000000 ]
       inertiaMatrix [
         1.028000e-01 8.710000e-02 5.790000e-02
         0.000000e+00 0.000000e+00 0.000000e+00

--- a/tests/expected/HumanLegacyShapes.proto
+++ b/tests/expected/HumanLegacyShapes.proto
@@ -1,0 +1,939 @@
+#VRML_SIM R2022a utf8
+# license: Apache License 2.0
+# license url: http://www.apache.org/licenses/LICENSE-2.0
+# This is a proto file for Webots for the HumanLegacyShapes
+# Extracted from: /home/benja/urdf2webots/tests/sources/gait2392_simbody/urdf/human.urdf
+
+PROTO HumanLegacyShapes [
+  field  SFVec3f     translation     0 0 0
+  field  SFRotation  rotation        0 0 1 0
+  field  SFString    name            "HumanLegacyShapes"  # Is `Robot.name`.
+  field  SFString    controller      "void"               # Is `Robot.controller`.
+  field  MFString    controllerArgs  []                   # Is `Robot.controllerArgs`.
+  field  SFString    customData      ""                   # Is `Robot.customData`.
+  field  SFBool      supervisor      FALSE                # Is `Robot.supervisor`.
+  field  SFBool      synchronization TRUE                 # Is `Robot.synchronization`.
+  field  SFBool      selfCollision   FALSE                # Is `Robot.selfCollision`.
+]
+{
+  Robot {
+    translation IS translation
+    rotation IS rotation
+    controller IS controller
+    controllerArgs IS controllerArgs
+    customData IS customData
+    supervisor IS supervisor
+    synchronization IS synchronization
+    selfCollision IS selfCollision
+    children [
+      Shape {
+        appearance DEF mat_pelvis_visual PBRAppearance {
+          baseColor 0.500000 0.500000 0.500000
+          roughness 1.000000
+          metalness 0
+        }
+        geometry DEF Pelvis Mesh {
+          url "root://tests/sources/gait2392_simbody/meshes/obj/Pelvis.obj"
+        }
+      }
+      HingeJoint {
+        jointParameters HingeJointParameters {
+          axis 0.000000 1.000000 0.000000
+          anchor -0.070700 0.083500 -0.066100
+        }
+        device [
+          RotationalMotor {
+            name "joint_femur_l"
+            maxVelocity 628.318530718
+            minPosition -3.141592741
+            maxPosition 3.141592741
+            maxTorque 10000000000.0
+          }
+          PositionSensor {
+            name "joint_femur_l_sensor"
+          }
+        ]
+        endPoint Solid {
+          translation -0.070700 0.083500 -0.066100
+          children [
+            Shape {
+              appearance DEF mat_femur_l_visual PBRAppearance {
+                baseColor 0.500000 0.500000 0.500000
+                roughness 1.000000
+                metalness 0
+              }
+              geometry DEF Femur_L Mesh {
+                url "root://tests/sources/gait2392_simbody/meshes/obj/Femur L.obj"
+              }
+            }
+            HingeJoint {
+              jointParameters HingeJointParameters {
+                axis 0.000000 1.000000 0.000000
+                anchor -0.004500 0.000000 -0.395821
+              }
+              device [
+                RotationalMotor {
+                  name "joint_tibia_l"
+                  maxVelocity 628.318530718
+                  minPosition -3.141592741
+                  maxPosition 3.141592741
+                  maxTorque 10000000000.0
+                }
+                PositionSensor {
+                  name "joint_tibia_l_sensor"
+                }
+              ]
+              endPoint Solid {
+                translation -0.004500 0.000000 -0.395821
+                children [
+                  Shape {
+                    appearance DEF mat_tibia_l_visual PBRAppearance {
+                      baseColor 0.500000 0.500000 0.500000
+                      roughness 1.000000
+                      metalness 0
+                    }
+                    geometry DEF Tibia_L Mesh {
+                      url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia L.obj"
+                    }
+                  }
+                  HingeJoint {
+                    jointParameters HingeJointParameters {
+                      axis 0.000000 1.000000 0.000000
+                      anchor 0.000000 0.000000 -0.430000
+                    }
+                    device [
+                      RotationalMotor {
+                        name "joint_talus_l"
+                        maxVelocity 628.318530718
+                        minPosition -3.141592741
+                        maxPosition 3.141592741
+                        maxTorque 10000000000.0
+                      }
+                      PositionSensor {
+                        name "joint_talus_l_sensor"
+                      }
+                    ]
+                    endPoint Solid {
+                      translation 0.000000 0.000000 -0.430000
+                      children [
+                        Shape {
+                          appearance DEF mat_talus_l_visual PBRAppearance {
+                            baseColor 0.500000 0.500000 0.500000
+                            roughness 1.000000
+                            metalness 0
+                          }
+                          geometry DEF Talus_L Mesh {
+                            url "root://tests/sources/gait2392_simbody/meshes/obj/Talus L.obj"
+                          }
+                        }
+                        HingeJoint {
+                          jointParameters HingeJointParameters {
+                            axis 0.000000 1.000000 0.000000
+                            anchor -0.048770 0.007920 -0.041950
+                          }
+                          device [
+                            RotationalMotor {
+                              name "joint_calcn_l"
+                              maxVelocity 628.318530718
+                              minPosition -3.141592741
+                              maxPosition 3.141592741
+                              maxTorque 10000000000.0
+                            }
+                            PositionSensor {
+                              name "joint_calcn_l_sensor"
+                            }
+                          ]
+                          endPoint Solid {
+                            translation -0.048770 0.007920 -0.041950
+                            children [
+                              Shape {
+                                appearance DEF mat_calcn_l_visual PBRAppearance {
+                                  baseColor 0.500000 0.500000 0.500000
+                                  roughness 1.000000
+                                  metalness 0
+                                }
+                                geometry DEF Calcn_L Mesh {
+                                  url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.obj"
+                                }
+                              }
+                              HingeJoint {
+                                jointParameters HingeJointParameters {
+                                  axis 0.000000 1.000000 0.000000
+                                  anchor 0.178800 0.001080 -0.002000
+                                }
+                                device [
+                                  RotationalMotor {
+                                    name "joint_toes_l"
+                                    maxVelocity 628.318530718
+                                    minPosition -3.141592741
+                                    maxPosition 3.141592741
+                                    maxTorque 10000000000.0
+                                  }
+                                  PositionSensor {
+                                    name "joint_toes_l_sensor"
+                                  }
+                                ]
+                                endPoint Solid {
+                                  translation 0.178800 0.001080 -0.002000
+                                  children [
+                                    Shape {
+                                      appearance DEF mat_toes_l_visual PBRAppearance {
+                                        baseColor 0.500000 0.500000 0.500000
+                                        roughness 1.000000
+                                        metalness 0
+                                      }
+                                      geometry DEF Toes_L Mesh {
+                                        url "root://tests/sources/gait2392_simbody/meshes/obj/Toes L.obj"
+                                      }
+                                    }
+                                  ]
+                                  name "toes_l"
+                                  boundingObject DEF Toes_L_001 Mesh {
+                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Toes L.001.obj"
+                                  }
+                                  physics Physics {
+                                    density -1
+                                    mass 0.216600
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
+                                    inertiaMatrix [
+                                      1.000000e-04 2.000000e-04 1.000000e-03
+                                      0.000000e+00 0.000000e+00 0.000000e+00
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                            name "calcn_l"
+                            boundingObject DEF Calcn_L_001 Mesh {
+                              url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
+                            }
+                            physics Physics {
+                              density -1
+                              mass 1.250000
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
+                              inertiaMatrix [
+                                1.400000e-03 3.900000e-03 4.100000e-03
+                                0.000000e+00 0.000000e+00 0.000000e+00
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                      name "talus_l"
+                      boundingObject DEF Talus_L_001 Mesh {
+                        url "root://tests/sources/gait2392_simbody/meshes/obj/Talus L.001.obj"
+                      }
+                      physics Physics {
+                        density -1
+                        mass 0.100000
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
+                        inertiaMatrix [
+                          1.000000e-03 1.000000e-03 1.000000e-03
+                          0.000000e+00 0.000000e+00 0.000000e+00
+                        ]
+                      }
+                    }
+                  }
+                ]
+                name "tibia_l"
+                boundingObject DEF Tibia_L_001 Mesh {
+                  url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia L.001.obj"
+                }
+                physics Physics {
+                  density -1
+                  mass 3.707500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
+                  inertiaMatrix [
+                    5.040000e-02 5.100000e-03 5.110000e-02
+                    0.000000e+00 0.000000e+00 0.000000e+00
+                  ]
+                }
+              }
+            }
+          ]
+          name "femur_l"
+          boundingObject DEF Femur_L_001 Mesh {
+            url "root://tests/sources/gait2392_simbody/meshes/obj/Femur L.001.obj"
+          }
+          physics Physics {
+            density -1
+            mass 9.301400
+            centerOfMass [ 0.000000 0.000000 0.000000 ]
+            inertiaMatrix [
+              1.339000e-01 3.510000e-02 1.412000e-01
+              0.000000e+00 0.000000e+00 0.000000e+00
+            ]
+          }
+        }
+      }
+      HingeJoint {
+        jointParameters HingeJointParameters {
+          anchor -0.070700 -0.083500 -0.066100
+        }
+        device [
+          RotationalMotor {
+            name "joint_femur_r"
+            maxVelocity 628.318530718
+            minPosition -3.141592741
+            maxPosition 3.141592741
+            maxTorque 10000000000.0
+          }
+          PositionSensor {
+            name "joint_femur_r_sensor"
+          }
+        ]
+        endPoint Solid {
+          translation -0.070700 -0.083500 -0.066100
+          children [
+            Shape {
+              appearance DEF mat_femur_r_visual PBRAppearance {
+                baseColor 0.500000 0.500000 0.500000
+                roughness 1.000000
+                metalness 0
+              }
+              geometry DEF Femur_R Mesh {
+                url "root://tests/sources/gait2392_simbody/meshes/obj/Femur R.obj"
+              }
+            }
+            HingeJoint {
+              jointParameters HingeJointParameters {
+                axis 0.000000 -1.000000 0.000000
+                anchor -0.004500 0.000000 -0.395821
+              }
+              device [
+                RotationalMotor {
+                  name "joint_tibia_r"
+                  maxVelocity 628.318530718
+                  minPosition -3.141592741
+                  maxPosition 3.141592741
+                  maxTorque 10000000000.0
+                }
+                PositionSensor {
+                  name "joint_tibia_r_sensor"
+                }
+              ]
+              endPoint Solid {
+                translation -0.004500 0.000000 -0.395821
+                children [
+                  Shape {
+                    appearance DEF mat_tibia_r_visual PBRAppearance {
+                      baseColor 0.500000 0.500000 0.500000
+                      roughness 1.000000
+                      metalness 0
+                    }
+                    geometry DEF Tibia_R Mesh {
+                      url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia R.obj"
+                    }
+                  }
+                  HingeJoint {
+                    jointParameters HingeJointParameters {
+                      axis 0.000000 -1.000000 0.000000
+                      anchor 0.000000 0.000000 -0.430000
+                    }
+                    device [
+                      RotationalMotor {
+                        name "joint_talus_r"
+                        maxVelocity 628.318530718
+                        minPosition -3.141592741
+                        maxPosition 3.141592741
+                        maxTorque 10000000000.0
+                      }
+                      PositionSensor {
+                        name "joint_talus_r_sensor"
+                      }
+                    ]
+                    endPoint Solid {
+                      translation 0.000000 0.000000 -0.430000
+                      children [
+                        Shape {
+                          appearance DEF mat_talus_r_visual PBRAppearance {
+                            baseColor 0.500000 0.500000 0.500000
+                            roughness 1.000000
+                            metalness 0
+                          }
+                          geometry DEF Talus_R Mesh {
+                            url "root://tests/sources/gait2392_simbody/meshes/obj/Talus R.obj"
+                          }
+                        }
+                        HingeJoint {
+                          jointParameters HingeJointParameters {
+                            axis 0.000000 -1.000000 0.000000
+                            anchor -0.048770 -0.007920 -0.041950
+                          }
+                          device [
+                            RotationalMotor {
+                              name "joint_calcn_r"
+                              maxVelocity 628.318530718
+                              minPosition -3.141592741
+                              maxPosition 3.141592741
+                              maxTorque 10000000000.0
+                            }
+                            PositionSensor {
+                              name "joint_calcn_r_sensor"
+                            }
+                          ]
+                          endPoint Solid {
+                            translation -0.048770 -0.007920 -0.041950
+                            children [
+                              Transform {
+                                scale 1.000000 -1.000000 1.000000
+                                children [
+                                  Shape {
+                                    appearance DEF mat_calcn_r_visual PBRAppearance {
+                                      baseColor 0.500000 0.500000 0.500000
+                                      roughness 1.000000
+                                      metalness 0
+                                    }
+                                    geometry DEF Calcn_L_cw Mesh {
+                                      url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.obj"
+                                      ccw FALSE
+                                    }
+                                  }
+                                ]
+                              }
+                              HingeJoint {
+                                jointParameters HingeJointParameters {
+                                  axis 0.000000 -1.000000 0.000000
+                                  anchor 0.178800 -0.001080 -0.002000
+                                }
+                                device [
+                                  RotationalMotor {
+                                    name "joint_toes_r"
+                                    maxVelocity 628.318530718
+                                    minPosition -3.141592741
+                                    maxPosition 3.141592741
+                                    maxTorque 10000000000.0
+                                  }
+                                  PositionSensor {
+                                    name "joint_toes_r_sensor"
+                                  }
+                                ]
+                                endPoint Solid {
+                                  translation 0.178800 -0.001080 -0.002000
+                                  children [
+                                    Shape {
+                                      appearance DEF mat_toes_r_visual PBRAppearance {
+                                        baseColor 0.500000 0.500000 0.500000
+                                        roughness 1.000000
+                                        metalness 0
+                                      }
+                                      geometry DEF Toes_R Mesh {
+                                        url "root://tests/sources/gait2392_simbody/meshes/obj/Toes R.obj"
+                                      }
+                                    }
+                                  ]
+                                  name "toes_r"
+                                  boundingObject DEF Toes_R_001 Mesh {
+                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Toes R.001.obj"
+                                  }
+                                  physics Physics {
+                                    density -1
+                                    mass 0.216600
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
+                                    inertiaMatrix [
+                                      1.000000e-04 2.000000e-04 1.000000e-03
+                                      0.000000e+00 0.000000e+00 0.000000e+00
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                            name "calcn_r"
+                            boundingObject Transform {
+                              scale 1.000000 -1.000000 1.000000
+                              children [
+                                DEF Calcn_L_001_cw Mesh {
+                                  url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
+                                  ccw FALSE
+                                }
+                              ]
+                            }
+                            physics Physics {
+                              density -1
+                              mass 1.250000
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
+                              inertiaMatrix [
+                                1.400000e-03 3.900000e-03 4.100000e-03
+                                0.000000e+00 0.000000e+00 0.000000e+00
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                      name "talus_r"
+                      boundingObject DEF Talus_R_001 Mesh {
+                        url "root://tests/sources/gait2392_simbody/meshes/obj/Talus R.001.obj"
+                      }
+                      physics Physics {
+                        density -1
+                        mass 0.100000
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
+                        inertiaMatrix [
+                          1.000000e-03 1.000000e-03 1.000000e-03
+                          0.000000e+00 0.000000e+00 0.000000e+00
+                        ]
+                      }
+                    }
+                  }
+                ]
+                name "tibia_r"
+                boundingObject DEF Tibia_R_001 Mesh {
+                  url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia R.001.obj"
+                }
+                physics Physics {
+                  density -1
+                  mass 3.707500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
+                  inertiaMatrix [
+                    5.040000e-02 5.100000e-03 5.110000e-02
+                    0.000000e+00 0.000000e+00 0.000000e+00
+                  ]
+                }
+              }
+            }
+          ]
+          name "femur_r"
+          boundingObject DEF Femur_R_001 Mesh {
+            url "root://tests/sources/gait2392_simbody/meshes/obj/Femur R.001.obj"
+          }
+          physics Physics {
+            density -1
+            mass 9.301400
+            centerOfMass [ 0.000000 0.000000 0.000000 ]
+            inertiaMatrix [
+              1.339000e-01 3.510000e-02 1.412000e-01
+              0.000000e+00 0.000000e+00 0.000000e+00
+            ]
+          }
+        }
+      }
+      HingeJoint {
+        jointParameters HingeJointParameters {
+          axis 0.000000 1.000000 0.000000
+          anchor -0.100700 0.000000 0.081500
+        }
+        device [
+          RotationalMotor {
+            name "joint_torso"
+            maxVelocity 628.318530718
+            minPosition -3.141592741
+            maxPosition 3.141592741
+            maxTorque 10000000000.0
+          }
+          PositionSensor {
+            name "joint_torso_sensor"
+          }
+        ]
+        endPoint Solid {
+          translation -0.100700 0.000000 0.081500
+          children [
+            Shape {
+              appearance DEF mat_torso_visual PBRAppearance {
+                baseColor 0.500000 0.500000 0.500000
+                roughness 1.000000
+                metalness 0
+              }
+              geometry DEF Torso Mesh {
+                url "root://tests/sources/gait2392_simbody/meshes/obj/Torso.obj"
+              }
+            }
+            HingeJoint {
+              jointParameters HingeJointParameters {
+                axis 0.000000 1.000000 0.000000
+                anchor 0.003155 0.170000 0.371500
+              }
+              device [
+                RotationalMotor {
+                  name "joint_humerus_l"
+                  maxVelocity 628.318530718
+                  minPosition -3.141592741
+                  maxPosition 3.141592741
+                  maxTorque 10000000000.0
+                }
+                PositionSensor {
+                  name "joint_humerus_l_sensor"
+                }
+              ]
+              endPoint Solid {
+                translation 0.003155 0.170000 0.371500
+                children [
+                  Shape {
+                    appearance DEF mat_humerus_l_visual PBRAppearance {
+                      baseColor 0.500000 0.500000 0.500000
+                      roughness 1.000000
+                      metalness 0
+                    }
+                    geometry DEF Humerus_L Mesh {
+                      url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus L.obj"
+                    }
+                  }
+                  HingeJoint {
+                    jointParameters HingeJointParameters {
+                      axis 0.000000 1.000000 0.000000
+                      anchor 0.013144 -0.009595 -0.286273
+                    }
+                    device [
+                      RotationalMotor {
+                        name "joint_ulna_l"
+                        maxVelocity 628.318530718
+                        minPosition -3.141592741
+                        maxPosition 3.141592741
+                        maxTorque 10000000000.0
+                      }
+                      PositionSensor {
+                        name "joint_ulna_l_sensor"
+                      }
+                    ]
+                    endPoint Solid {
+                      translation 0.013144 -0.009595 -0.286273
+                      children [
+                        Shape {
+                          appearance DEF mat_ulna_l_visual PBRAppearance {
+                            baseColor 0.500000 0.500000 0.500000
+                            roughness 1.000000
+                            metalness 0
+                          }
+                          geometry DEF Ulna_L Mesh {
+                            url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna L.obj"
+                          }
+                        }
+                        HingeJoint {
+                          jointParameters HingeJointParameters {
+                            axis 0.000000 1.000000 0.000000
+                            anchor -0.006727 0.026083 -0.013007
+                          }
+                          device [
+                            RotationalMotor {
+                              name "joint_radius_l"
+                              maxVelocity 628.318530718
+                              minPosition -3.141592741
+                              maxPosition 3.141592741
+                              maxTorque 10000000000.0
+                            }
+                            PositionSensor {
+                              name "joint_radius_l_sensor"
+                            }
+                          ]
+                          endPoint Solid {
+                            translation -0.006727 0.026083 -0.013007
+                            children [
+                              Shape {
+                                appearance DEF mat_radius_l_visual PBRAppearance {
+                                  baseColor 0.500000 0.500000 0.500000
+                                  roughness 1.000000
+                                  metalness 0
+                                }
+                                geometry DEF Radius_L Mesh {
+                                  url "root://tests/sources/gait2392_simbody/meshes/obj/Radius L.obj"
+                                }
+                              }
+                              HingeJoint {
+                                jointParameters HingeJointParameters {
+                                  axis 0.000000 1.000000 0.000000
+                                  anchor -0.008797 0.013610 -0.235841
+                                }
+                                device [
+                                  RotationalMotor {
+                                    name "joint_hand_l"
+                                    maxVelocity 628.318530718
+                                    minPosition -3.141592741
+                                    maxPosition 3.141592741
+                                    maxTorque 10000000000.0
+                                  }
+                                  PositionSensor {
+                                    name "joint_hand_l_sensor"
+                                  }
+                                ]
+                                endPoint Solid {
+                                  translation -0.008797 0.013610 -0.235841
+                                  children [
+                                    Shape {
+                                      appearance DEF mat_hand_l_visual PBRAppearance {
+                                        baseColor 0.500000 0.500000 0.500000
+                                        roughness 1.000000
+                                        metalness 0
+                                      }
+                                      geometry DEF Hand_L Mesh {
+                                        url "root://tests/sources/gait2392_simbody/meshes/obj/Hand L.obj"
+                                      }
+                                    }
+                                  ]
+                                  name "hand_l"
+                                  boundingObject DEF Hand_L_001 Mesh {
+                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Hand L.001.obj"
+                                  }
+                                  physics Physics {
+                                    density -1
+                                    mass 0.457500
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
+                                    inertiaMatrix [
+                                      8.920000e-04 5.470000e-04 1.340000e-03
+                                      0.000000e+00 0.000000e+00 0.000000e+00
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                            name "radius_l"
+                            boundingObject DEF Radius_L_001 Mesh {
+                              url "root://tests/sources/gait2392_simbody/meshes/obj/Radius L.001.obj"
+                            }
+                            physics Physics {
+                              density -1
+                              mass 0.607500
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
+                              inertiaMatrix [
+                                2.962000e-03 6.180000e-04 3.213000e-03
+                                0.000000e+00 0.000000e+00 0.000000e+00
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                      name "ulna_l"
+                      boundingObject DEF Ulna_L_001 Mesh {
+                        url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna L.001.obj"
+                      }
+                      physics Physics {
+                        density -1
+                        mass 0.607500
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
+                        inertiaMatrix [
+                          2.962000e-03 6.180000e-04 3.213000e-03
+                          0.000000e+00 0.000000e+00 0.000000e+00
+                        ]
+                      }
+                    }
+                  }
+                ]
+                name "humerus_l"
+                boundingObject DEF Humerus_L_001 Mesh {
+                  url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus L.001.obj"
+                }
+                physics Physics {
+                  density -1
+                  mass 2.032500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
+                  inertiaMatrix [
+                    1.194600e-02 4.121000e-03 1.340900e-02
+                    0.000000e+00 0.000000e+00 0.000000e+00
+                  ]
+                }
+              }
+            }
+            HingeJoint {
+              jointParameters HingeJointParameters {
+                axis 0.000000 -1.000000 0.000000
+                anchor 0.003155 -0.170000 0.371500
+              }
+              device [
+                RotationalMotor {
+                  name "joint_humerus_r"
+                  maxVelocity 628.318530718
+                  minPosition -3.141592741
+                  maxPosition 3.141592741
+                  maxTorque 10000000000.0
+                }
+                PositionSensor {
+                  name "joint_humerus_r_sensor"
+                }
+              ]
+              endPoint Solid {
+                translation 0.003155 -0.170000 0.371500
+                children [
+                  Shape {
+                    appearance DEF mat_humerus_r_visual PBRAppearance {
+                      baseColor 0.500000 0.500000 0.500000
+                      roughness 1.000000
+                      metalness 0
+                    }
+                    geometry DEF Humerus_R Mesh {
+                      url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus R.obj"
+                    }
+                  }
+                  HingeJoint {
+                    jointParameters HingeJointParameters {
+                      axis 0.000000 -1.000000 0.000000
+                      anchor 0.013144 0.009595 -0.286273
+                    }
+                    device [
+                      RotationalMotor {
+                        name "joint_ulna_r"
+                        maxVelocity 628.318530718
+                        minPosition -3.141592741
+                        maxPosition 3.141592741
+                        maxTorque 10000000000.0
+                      }
+                      PositionSensor {
+                        name "joint_ulna_r_sensor"
+                      }
+                    ]
+                    endPoint Solid {
+                      translation 0.013144 0.009595 -0.286273
+                      children [
+                        Shape {
+                          appearance DEF mat_ulna_r_visual PBRAppearance {
+                            baseColor 0.500000 0.500000 0.500000
+                            roughness 1.000000
+                            metalness 0
+                          }
+                          geometry DEF Ulna_R Mesh {
+                            url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna R.obj"
+                          }
+                        }
+                        HingeJoint {
+                          jointParameters HingeJointParameters {
+                            axis 0.000000 -1.000000 0.000000
+                            anchor -0.006727 -0.026083 -0.013007
+                          }
+                          device [
+                            RotationalMotor {
+                              name "joint_radius_r"
+                              maxVelocity 628.318530718
+                              minPosition -3.141592741
+                              maxPosition 3.141592741
+                              maxTorque 10000000000.0
+                            }
+                            PositionSensor {
+                              name "joint_radius_r_sensor"
+                            }
+                          ]
+                          endPoint Solid {
+                            translation -0.006727 -0.026083 -0.013007
+                            children [
+                              Shape {
+                                appearance DEF mat_radius_r_visual PBRAppearance {
+                                  baseColor 0.500000 0.500000 0.500000
+                                  roughness 1.000000
+                                  metalness 0
+                                }
+                                geometry DEF Radius_R Mesh {
+                                  url "root://tests/sources/gait2392_simbody/meshes/obj/Radius R.obj"
+                                }
+                              }
+                              HingeJoint {
+                                jointParameters HingeJointParameters {
+                                  axis 0.000000 -1.000000 0.000000
+                                  anchor -0.008797 -0.013610 -0.235841
+                                }
+                                device [
+                                  RotationalMotor {
+                                    name "joint_hand_r"
+                                    maxVelocity 628.318530718
+                                    minPosition -3.141592741
+                                    maxPosition 3.141592741
+                                    maxTorque 10000000000.0
+                                  }
+                                  PositionSensor {
+                                    name "joint_hand_r_sensor"
+                                  }
+                                ]
+                                endPoint Solid {
+                                  translation -0.008797 -0.013610 -0.235841
+                                  children [
+                                    Shape {
+                                      appearance DEF mat_hand_r_visual PBRAppearance {
+                                        baseColor 0.500000 0.500000 0.500000
+                                        roughness 1.000000
+                                        metalness 0
+                                      }
+                                      geometry DEF Hand_R Mesh {
+                                        url "root://tests/sources/gait2392_simbody/meshes/obj/Hand R.obj"
+                                      }
+                                    }
+                                  ]
+                                  name "hand_r"
+                                  boundingObject DEF Hand_R_001 Mesh {
+                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Hand R.001.obj"
+                                  }
+                                  physics Physics {
+                                    density -1
+                                    mass 0.457500
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
+                                    inertiaMatrix [
+                                      8.920000e-04 5.470000e-04 1.340000e-03
+                                      0.000000e+00 0.000000e+00 0.000000e+00
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                            name "radius_r"
+                            boundingObject DEF Radius_R_001 Mesh {
+                              url "root://tests/sources/gait2392_simbody/meshes/obj/Radius R.001.obj"
+                            }
+                            physics Physics {
+                              density -1
+                              mass 0.607500
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
+                              inertiaMatrix [
+                                2.962000e-03 6.180000e-04 3.213000e-03
+                                0.000000e+00 0.000000e+00 0.000000e+00
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                      name "ulna_r"
+                      boundingObject DEF Ulna_R_001 Mesh {
+                        url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna R.001.obj"
+                      }
+                      physics Physics {
+                        density -1
+                        mass 0.607500
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
+                        inertiaMatrix [
+                          2.962000e-03 6.180000e-04 3.213000e-03
+                          0.000000e+00 0.000000e+00 0.000000e+00
+                        ]
+                      }
+                    }
+                  }
+                ]
+                name "humerus_r"
+                boundingObject DEF Humerus_R_001 Mesh {
+                  url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus R.001.obj"
+                }
+                physics Physics {
+                  density -1
+                  mass 2.032500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
+                  inertiaMatrix [
+                    1.194600e-02 4.121000e-03 1.340900e-02
+                    0.000000e+00 0.000000e+00 0.000000e+00
+                  ]
+                }
+              }
+            }
+          ]
+          name "torso"
+          boundingObject DEF Torso_001 Mesh {
+            url "root://tests/sources/gait2392_simbody/meshes/obj/Torso.001.obj"
+          }
+          physics Physics {
+            density -1
+            mass 26.826600
+            centerOfMass [ 0.000000 0.000000 0.000000 ]
+            inertiaMatrix [
+              1.474500e+00 7.555000e-01 1.431400e+00
+              0.000000e+00 0.000000e+00 0.000000e+00
+            ]
+          }
+        }
+      }
+    ]
+    name IS name
+    boundingObject DEF Pelvis_001 Mesh {
+      url "root://tests/sources/gait2392_simbody/meshes/obj/Pelvis.001.obj"
+    }
+    physics Physics {
+      density -1
+      mass 11.777000
+      centerOfMass [ 0.000000 0.000000 0.000000 ]
+      inertiaMatrix [
+        1.028000e-01 8.710000e-02 5.790000e-02
+        0.000000e+00 0.000000e+00 0.000000e+00
+      ]
+    }
+  }
+}

--- a/tests/expected/HumanLegacyShapes.proto
+++ b/tests/expected/HumanLegacyShapes.proto
@@ -194,7 +194,6 @@ PROTO HumanLegacyShapes [
                                   physics Physics {
                                     density -1
                                     mass 0.216600
-                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       1.000000e-04 2.000000e-04 1.000000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -210,7 +209,6 @@ PROTO HumanLegacyShapes [
                             physics Physics {
                               density -1
                               mass 1.250000
-                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 1.400000e-03 3.900000e-03 4.100000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -226,7 +224,6 @@ PROTO HumanLegacyShapes [
                       physics Physics {
                         density -1
                         mass 0.100000
-                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           1.000000e-03 1.000000e-03 1.000000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -242,7 +239,6 @@ PROTO HumanLegacyShapes [
                 physics Physics {
                   density -1
                   mass 3.707500
-                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     5.040000e-02 5.100000e-03 5.110000e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -258,7 +254,6 @@ PROTO HumanLegacyShapes [
           physics Physics {
             density -1
             mass 9.301400
-            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.339000e-01 3.510000e-02 1.412000e-01
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -429,7 +424,6 @@ PROTO HumanLegacyShapes [
                                   physics Physics {
                                     density -1
                                     mass 0.216600
-                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       1.000000e-04 2.000000e-04 1.000000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -451,7 +445,6 @@ PROTO HumanLegacyShapes [
                             physics Physics {
                               density -1
                               mass 1.250000
-                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 1.400000e-03 3.900000e-03 4.100000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -467,7 +460,6 @@ PROTO HumanLegacyShapes [
                       physics Physics {
                         density -1
                         mass 0.100000
-                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           1.000000e-03 1.000000e-03 1.000000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -483,7 +475,6 @@ PROTO HumanLegacyShapes [
                 physics Physics {
                   density -1
                   mass 3.707500
-                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     5.040000e-02 5.100000e-03 5.110000e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -499,7 +490,6 @@ PROTO HumanLegacyShapes [
           physics Physics {
             density -1
             mass 9.301400
-            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.339000e-01 3.510000e-02 1.412000e-01
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -665,7 +655,6 @@ PROTO HumanLegacyShapes [
                                   physics Physics {
                                     density -1
                                     mass 0.457500
-                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       8.920000e-04 5.470000e-04 1.340000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -681,7 +670,6 @@ PROTO HumanLegacyShapes [
                             physics Physics {
                               density -1
                               mass 0.607500
-                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 2.962000e-03 6.180000e-04 3.213000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -697,7 +685,6 @@ PROTO HumanLegacyShapes [
                       physics Physics {
                         density -1
                         mass 0.607500
-                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           2.962000e-03 6.180000e-04 3.213000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -713,7 +700,6 @@ PROTO HumanLegacyShapes [
                 physics Physics {
                   density -1
                   mass 2.032500
-                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     1.194600e-02 4.121000e-03 1.340900e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -849,7 +835,6 @@ PROTO HumanLegacyShapes [
                                   physics Physics {
                                     density -1
                                     mass 0.457500
-                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       8.920000e-04 5.470000e-04 1.340000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -865,7 +850,6 @@ PROTO HumanLegacyShapes [
                             physics Physics {
                               density -1
                               mass 0.607500
-                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 2.962000e-03 6.180000e-04 3.213000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -881,7 +865,6 @@ PROTO HumanLegacyShapes [
                       physics Physics {
                         density -1
                         mass 0.607500
-                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           2.962000e-03 6.180000e-04 3.213000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -897,7 +880,6 @@ PROTO HumanLegacyShapes [
                 physics Physics {
                   density -1
                   mass 2.032500
-                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     1.194600e-02 4.121000e-03 1.340900e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -913,7 +895,6 @@ PROTO HumanLegacyShapes [
           physics Physics {
             density -1
             mass 26.826600
-            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.474500e+00 7.555000e-01 1.431400e+00
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -929,7 +910,6 @@ PROTO HumanLegacyShapes [
     physics Physics {
       density -1
       mass 11.777000
-      centerOfMass [ 0.000000 0.000000 0.000000 ]
       inertiaMatrix [
         1.028000e-01 8.710000e-02 5.790000e-02
         0.000000e+00 0.000000e+00 0.000000e+00

--- a/tests/expected/HumanR2022a.proto
+++ b/tests/expected/HumanR2022a.proto
@@ -1,19 +1,19 @@
 #VRML_SIM R2022a utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
-# This is a proto file for Webots for the HumanLegacyShapes
+# This is a proto file for Webots for the HumanR2022a
 # Extracted from: /home/benja/urdf2webots/tests/sources/gait2392_simbody/urdf/human.urdf
 
-PROTO HumanLegacyShapes [
+PROTO HumanR2022a [
   field  SFVec3f     translation     0 0 0
   field  SFRotation  rotation        0 0 1 0
-  field  SFString    name            "HumanLegacyShapes"  # Is `Robot.name`.
-  field  SFString    controller      "void"               # Is `Robot.controller`.
-  field  MFString    controllerArgs  []                   # Is `Robot.controllerArgs`.
-  field  SFString    customData      ""                   # Is `Robot.customData`.
-  field  SFBool      supervisor      FALSE                # Is `Robot.supervisor`.
-  field  SFBool      synchronization TRUE                 # Is `Robot.synchronization`.
-  field  SFBool      selfCollision   FALSE                # Is `Robot.selfCollision`.
+  field  SFString    name            "HumanR2022a"  # Is `Robot.name`.
+  field  SFString    controller      "void"         # Is `Robot.controller`.
+  field  MFString    controllerArgs  []             # Is `Robot.controllerArgs`.
+  field  SFString    customData      ""             # Is `Robot.customData`.
+  field  SFBool      supervisor      FALSE          # Is `Robot.supervisor`.
+  field  SFBool      synchronization TRUE           # Is `Robot.synchronization`.
+  field  SFBool      selfCollision   FALSE          # Is `Robot.selfCollision`.
 ]
 {
   Robot {

--- a/tests/expected/KukaLbrIiwa14R820.proto
+++ b/tests/expected/KukaLbrIiwa14R820.proto
@@ -1,4 +1,4 @@
-#VRML_SIM R2022a utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # This is a proto file for Webots for the KukaLbrIiwa14R820

--- a/tests/expected/MotomanSia20d.proto
+++ b/tests/expected/MotomanSia20d.proto
@@ -1,4 +1,4 @@
-#VRML_SIM R2022a utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # This is a proto file for Webots for the MotomanSia20d

--- a/tests/expected/RobotWithDummyLink.proto
+++ b/tests/expected/RobotWithDummyLink.proto
@@ -1,4 +1,4 @@
-#VRML_SIM R2022a utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # This is a proto file for Webots for the RobotWithDummyLink

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -31,6 +31,12 @@ modelPathsProto = [
         'arguments': ''
     },
     {
+        'input': humanFilePath,
+        'output': os.path.join(resultDirectory, 'HumanLegacyShapes.proto'),
+        'expected': [os.path.join(expectedDirectory, 'HumanLegacyShapes.proto')],
+        'arguments': '--legacy-shapes'
+    },
+    {
         'input': os.path.join(sourceDirectory, 'kuka_lbr_iiwa_support/urdf/model.urdf'),
         'output': os.path.join(resultDirectory, 'KukaLbrIiwa14R820.proto'),
         'expected': [os.path.join(expectedDirectory, 'KukaLbrIiwa14R820.proto')],

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -32,9 +32,9 @@ modelPathsProto = [
     },
     {
         'input': humanFilePath,
-        'output': os.path.join(resultDirectory, 'HumanLegacyShapes.proto'),
-        'expected': [os.path.join(expectedDirectory, 'HumanLegacyShapes.proto')],
-        'arguments': '--legacy-shapes'
+        'output': os.path.join(resultDirectory, 'HumanR2022a.proto'),
+        'expected': [os.path.join(expectedDirectory, 'HumanR2022a.proto')],
+        'arguments': '--target=R2022a'
     },
     {
         'input': os.path.join(sourceDirectory, 'kuka_lbr_iiwa_support/urdf/model.urdf'),
@@ -77,9 +77,6 @@ def fileCompare(file1, file2):
         for i, (line1, line2) in enumerate(zip(f1, f2)):
             if line1.startswith('# Extracted from') and line2.startswith('# Extracted from'):
                 # This line may differ.
-                continue
-            elif line1.startswith('#VRML_SIM') and line2.startswith('#VRML_SIM'):
-                # This line may differ according to Webots version used
                 continue
             elif line1 != line2:
                 # Prints the difference between result and expected line

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -61,7 +61,7 @@ def mkdirSafe(directory):
 
 def convertUrdfFile(input=None, output=None, robotName=None, normal=False, boxCollision=False,
                  toolSlot=None, initTranslation='0 0 0', initRotation='0 0 1 0',
-                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None, legacyShapes=False):
+                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None, targetVersion='R2022b'):
     """Convert a URDF file into a Webots PROTO file or Robot node string."""
     urdfContent = None
     if not input:
@@ -89,7 +89,7 @@ def convertUrdfFile(input=None, output=None, robotName=None, normal=False, boxCo
 
     return convertUrdfContent(urdfContent, output, robotName, normal, boxCollision,
                  toolSlot, initTranslation, initRotation,
-                 initPos, linkToDef, jointToDef, relativePathPrefix, legacyShapes)
+                 initPos, linkToDef, jointToDef, relativePathPrefix, targetVersion)
 
 
 convertUrdfFile.urdfPath = None
@@ -97,7 +97,7 @@ convertUrdfFile.urdfPath = None
 
 def convertUrdfContent(input, output=None, robotName=None, normal=False, boxCollision=False,
                  toolSlot=None, initTranslation='0 0 0', initRotation='0 0 1 0',
-                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None, legacyShapes=False):
+                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None, targetVersion='R2022b'):
     """
     Convert a URDF content string into a Webots PROTO file or Robot node string.
     The current working directory will be used for relative paths in your URDF file.
@@ -148,10 +148,10 @@ def convertUrdfContent(input, output=None, robotName=None, normal=False, boxColl
     # Required resets in case of multiple conversions
     urdf2webots.writeRobot.indexSolid = 0
     urdf2webots.writeRobot.staticBase = False
-    urdf2webots.writeRobot.legacyShapes = legacyShapes
+    urdf2webots.writeRobot.targetVersion = targetVersion
     urdf2webots.parserURDF.Material.namedMaterial.clear()
     urdf2webots.parserURDF.Geometry.reference.clear()
-    urdf2webots.parserURDF.legacyShapes = legacyShapes
+    urdf2webots.parserURDF.targetVersion = targetVersion
 
     # Replace "package://(.*)" occurences
     for match in re.finditer('"package://(.*?)"', input):
@@ -321,9 +321,9 @@ if __name__ == '__main__':
     optParser.add_option('--relative-path-prefix', dest='relativePathPrefix', default=None,
                          help='If set and --input not specified, relative paths in your URDF file will be treated relatively to it '
                          'rather than relatively to the current directory from which the script is called.')
-    optParser.add_option('--legacy-shapes', dest='legacyShapes', action='store_true', default=False,
-                         help='If set, visual nodes will be represented by a combination of Mesh and PBRAppearance nodes.')
+    optParser.add_option('--target', dest='targetVersion', default='R2022b', choices=['R2022b', 'R2022a', 'R2021b', 'R2021a', 'R2020b', 'R2020a'],
+                         help='Sets the Webots version the PROTO will target.')
     options, args = optParser.parse_args()
     convertUrdfFile(options.input, options.output, options.robotName, options.normal, options.boxCollision, options.toolSlot,
         options.initTranslation, options.initRotation, options.initPos, options.linkToDef, options.jointToDef, options.relativePathPrefix,
-        options.legacyShapes)
+        options.targetVersion)

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -61,7 +61,7 @@ def mkdirSafe(directory):
 
 def convertUrdfFile(input=None, output=None, robotName=None, normal=False, boxCollision=False,
                  toolSlot=None, initTranslation='0 0 0', initRotation='0 0 1 0',
-                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None):
+                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None, legacyShapes=False):
     """Convert a URDF file into a Webots PROTO file or Robot node string."""
     urdfContent = None
     if not input:
@@ -89,7 +89,7 @@ def convertUrdfFile(input=None, output=None, robotName=None, normal=False, boxCo
 
     return convertUrdfContent(urdfContent, output, robotName, normal, boxCollision,
                  toolSlot, initTranslation, initRotation,
-                 initPos, linkToDef, jointToDef, relativePathPrefix)
+                 initPos, linkToDef, jointToDef, relativePathPrefix, legacyShapes)
 
 
 convertUrdfFile.urdfPath = None
@@ -97,7 +97,7 @@ convertUrdfFile.urdfPath = None
 
 def convertUrdfContent(input, output=None, robotName=None, normal=False, boxCollision=False,
                  toolSlot=None, initTranslation='0 0 0', initRotation='0 0 1 0',
-                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None):
+                 initPos=None, linkToDef=False, jointToDef=False, relativePathPrefix=None, legacyShapes=False):
     """
     Convert a URDF content string into a Webots PROTO file or Robot node string.
     The current working directory will be used for relative paths in your URDF file.
@@ -148,8 +148,10 @@ def convertUrdfContent(input, output=None, robotName=None, normal=False, boxColl
     # Required resets in case of multiple conversions
     urdf2webots.writeRobot.indexSolid = 0
     urdf2webots.writeRobot.staticBase = False
+    urdf2webots.writeRobot.legacyShapes = legacyShapes
     urdf2webots.parserURDF.Material.namedMaterial.clear()
     urdf2webots.parserURDF.Geometry.reference.clear()
+    urdf2webots.parserURDF.legacyShapes = legacyShapes
 
     # Replace "package://(.*)" occurences
     for match in re.finditer('"package://(.*?)"', input):
@@ -319,6 +321,9 @@ if __name__ == '__main__':
     optParser.add_option('--relative-path-prefix', dest='relativePathPrefix', default=None,
                          help='If set and --input not specified, relative paths in your URDF file will be treated relatively to it '
                          'rather than relatively to the current directory from which the script is called.')
+    optParser.add_option('--legacy-shapes', dest='legacyShapes', action='store_true', default=False,
+                         help='If set, visual nodes will be represented by a combination of Mesh and PBRAppearance nodes.')
     options, args = optParser.parse_args()
     convertUrdfFile(options.input, options.output, options.robotName, options.normal, options.boxCollision, options.toolSlot,
-        options.initTranslation, options.initRotation, options.initPos, options.linkToDef, options.jointToDef, options.relativePathPrefix)
+        options.initTranslation, options.initRotation, options.initPos, options.linkToDef, options.jointToDef, options.relativePathPrefix,
+        options.legacyShapes)

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -17,7 +17,7 @@ from urdf2webots.math_utils import convertRPYtoEulerAxis, rotateVector, combineR
 
 # to pass from external
 robotName = ''
-legacyShapes = False
+targetVersion = 'R2022b'
 
 class Inertia():
     """Define inertia object."""
@@ -564,21 +564,21 @@ def getVisual(link, node, path):
                 visual.scale[2] = float(meshScale[2])
                 if visual.scale[0] * visual.scale[1] * visual.scale[2] < 0.0:
                     extension = os.path.splitext(meshfile)[1].lower()
-                    if extension in ['.dae', '.obj'] and not legacyShapes:
+                    if extension in ['.dae', '.obj'] and targetVersion == 'R2022b':
                         visual.geometry.cadShape.ccw = False
                     else:
                         visual.geometry.mesh.ccw = False
             extension = os.path.splitext(meshfile)[1].lower()
             if extension in ['.dae', '.obj', '.stl']:
                 name = os.path.splitext(os.path.basename(meshfile))[0]
-                if extension in ['.dae', '.obj'] and not legacyShapes:
+                if extension in ['.dae', '.obj'] and targetVersion == 'R2022b':
                     name += '_visual'
                 if not visual.geometry.mesh.ccw:
                     name += '_cw'
                 if name in Geometry.reference:
                     visual.geometry = Geometry.reference[name]
                 else:
-                    if extension in ['.dae', '.obj'] and not legacyShapes:
+                    if extension in ['.dae', '.obj'] and targetVersion == 'R2022b':
                         visual.geometry.cadShape.url = '"' + meshfile + '"'
                     else:
                         visual.geometry.mesh.url = '"' + meshfile + '"'

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -17,7 +17,7 @@ from urdf2webots.math_utils import convertRPYtoEulerAxis, rotateVector, combineR
 
 # to pass from external
 robotName = ''
-
+legacyShapes = False
 
 class Inertia():
     """Define inertia object."""
@@ -564,21 +564,21 @@ def getVisual(link, node, path):
                 visual.scale[2] = float(meshScale[2])
                 if visual.scale[0] * visual.scale[1] * visual.scale[2] < 0.0:
                     extension = os.path.splitext(meshfile)[1].lower()
-                    if extension in ['.dae', '.obj']:
+                    if extension in ['.dae', '.obj'] and not legacyShapes:
                         visual.geometry.cadShape.ccw = False
                     else:
                         visual.geometry.mesh.ccw = False
             extension = os.path.splitext(meshfile)[1].lower()
             if extension in ['.dae', '.obj', '.stl']:
                 name = os.path.splitext(os.path.basename(meshfile))[0]
-                if extension in ['.dae', '.obj']:
+                if extension in ['.dae', '.obj'] and not legacyShapes:
                     name += '_visual'
                 if not visual.geometry.mesh.ccw:
                     name += '_cw'
                 if name in Geometry.reference:
                     visual.geometry = Geometry.reference[name]
                 else:
-                    if extension in ['.dae', '.obj']:
+                    if extension in ['.dae', '.obj'] and not legacyShapes:
                         visual.geometry.cadShape.url = '"' + meshfile + '"'
                     else:
                         visual.geometry.mesh.url = '"' + meshfile + '"'

--- a/urdf2webots/parserURDF.py
+++ b/urdf2webots/parserURDF.py
@@ -564,21 +564,21 @@ def getVisual(link, node, path):
                 visual.scale[2] = float(meshScale[2])
                 if visual.scale[0] * visual.scale[1] * visual.scale[2] < 0.0:
                     extension = os.path.splitext(meshfile)[1].lower()
-                    if extension in ['.dae', '.obj'] and targetVersion == 'R2022b':
+                    if extension in ['.dae', '.obj'] and targetVersion >= 'R2022b':
                         visual.geometry.cadShape.ccw = False
                     else:
                         visual.geometry.mesh.ccw = False
             extension = os.path.splitext(meshfile)[1].lower()
             if extension in ['.dae', '.obj', '.stl']:
                 name = os.path.splitext(os.path.basename(meshfile))[0]
-                if extension in ['.dae', '.obj'] and targetVersion == 'R2022b':
+                if extension in ['.dae', '.obj'] and targetVersion >= 'R2022b':
                     name += '_visual'
                 if not visual.geometry.mesh.ccw:
                     name += '_cw'
                 if name in Geometry.reference:
                     visual.geometry = Geometry.reference[name]
                 else:
-                    if extension in ['.dae', '.obj'] and targetVersion == 'R2022b':
+                    if extension in ['.dae', '.obj'] and targetVersion >= 'R2022b':
                         visual.geometry.cadShape.url = '"' + meshfile + '"'
                     else:
                         visual.geometry.mesh.url = '"' + meshfile + '"'

--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -13,6 +13,7 @@ initPos = None
 linkToDef = False
 jointToDef = False
 indexSolid = 0
+legacyShapes = False
 
 
 class RGB():
@@ -341,7 +342,7 @@ def URDFVisual(robotFile, visualNode, level, normal=False):
     indent = '  '
     shapeLevel = level
 
-    if visualNode.geometry.cadShape.url:
+    if visualNode.geometry.cadShape.url and not legacyShapes:
         if visualNode.geometry.defName is not None:
             robotFile.write(shapeLevel * indent + 'USE %s\n' % visualNode.geometry.defName)
         else:

--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -219,9 +219,10 @@ def writeLinkPhysics(robotFile, link, level):
     robotFile.write((level + 1) * indent + 'physics Physics {\n')
     robotFile.write((level + 2) * indent + 'density -1\n')
     robotFile.write((level + 2) * indent + 'mass %lf\n' % link.inertia.mass)
-    robotFile.write((level + 2) * indent + 'centerOfMass [ %lf %lf %lf ]\n' % (link.inertia.position[0],
-                                                                               link.inertia.position[1],
-                                                                               link.inertia.position[2]))
+    if link.inertia.position[0] != 0.0 and link.inertia.position[1] != 0.0 and link.inertia.position[2] != 0:
+        robotFile.write((level + 2) * indent + 'centerOfMass [ %lf %lf %lf ]\n' % (link.inertia.position[0],
+                                                                                   link.inertia.position[1],
+                                                                                   link.inertia.position[2]))
     if link.inertia.ixx > 0.0 and link.inertia.iyy > 0.0 and link.inertia.izz > 0.0:
         i = link.inertia
         inertiaMatrix = [i.ixx, i.ixy, i.ixz, i.ixy, i.iyy, i.iyz, i.ixz, i.iyz, i.izz]

--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -13,7 +13,7 @@ initPos = None
 linkToDef = False
 jointToDef = False
 indexSolid = 0
-legacyShapes = False
+targetVersion = 'R2022b'
 
 
 class RGB():
@@ -47,7 +47,7 @@ def RGBA2RGB(RGBA_color, RGB_background=RGB()):
 
 def header(robotFile, srcFile=None, protoName=None, tags=[]):
     """Specify VRML file header."""
-    robotFile.write('#VRML_SIM R2022a utf8\n')
+    robotFile.write('#VRML_SIM %s utf8\n' % targetVersion)
     robotFile.write('# license: Apache License 2.0\n')
     robotFile.write('# license url: http://www.apache.org/licenses/LICENSE-2.0\n')
     if tags:
@@ -343,7 +343,7 @@ def URDFVisual(robotFile, visualNode, level, normal=False):
     indent = '  '
     shapeLevel = level
 
-    if visualNode.geometry.cadShape.url and not legacyShapes:
+    if visualNode.geometry.cadShape.url and targetVersion == 'R2022b':
         if visualNode.geometry.defName is not None:
             robotFile.write(shapeLevel * indent + 'USE %s\n' % visualNode.geometry.defName)
         else:

--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -343,7 +343,7 @@ def URDFVisual(robotFile, visualNode, level, normal=False):
     indent = '  '
     shapeLevel = level
 
-    if visualNode.geometry.cadShape.url and targetVersion == 'R2022b':
+    if visualNode.geometry.cadShape.url and targetVersion >= 'R2022b':
         if visualNode.geometry.defName is not None:
             robotFile.write(shapeLevel * indent + 'USE %s\n' % visualNode.geometry.defName)
         else:


### PR DESCRIPTION
This PR converts URDF visuals to either Mesh+PBRAppearance or CadShape depending on the value provided to `--target`

It also doesn't write centerOfMass if they are at their default value.