### PR TITLE
Restore center of mass in the presence of inertia matrix

### DIFF
--- a/tests/expected/Human.proto
+++ b/tests/expected/Human.proto
@@ -152,6 +152,7 @@ PROTO Human [
                                   physics Physics {
                                     density -1
                                     mass 0.216600
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       1.000000e-04 2.000000e-04 1.000000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -167,6 +168,7 @@ PROTO Human [
                             physics Physics {
                               density -1
                               mass 1.250000
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 1.400000e-03 3.900000e-03 4.100000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -182,6 +184,7 @@ PROTO Human [
                       physics Physics {
                         density -1
                         mass 0.100000
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           1.000000e-03 1.000000e-03 1.000000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -197,6 +200,7 @@ PROTO Human [
                 physics Physics {
                   density -1
                   mass 3.707500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     5.040000e-02 5.100000e-03 5.110000e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -212,6 +216,7 @@ PROTO Human [
           physics Physics {
             density -1
             mass 9.301400
+            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.339000e-01 3.510000e-02 1.412000e-01
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -344,6 +349,7 @@ PROTO Human [
                                   physics Physics {
                                     density -1
                                     mass 0.216600
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       1.000000e-04 2.000000e-04 1.000000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -365,6 +371,7 @@ PROTO Human [
                             physics Physics {
                               density -1
                               mass 1.250000
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 1.400000e-03 3.900000e-03 4.100000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -380,6 +387,7 @@ PROTO Human [
                       physics Physics {
                         density -1
                         mass 0.100000
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           1.000000e-03 1.000000e-03 1.000000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -395,6 +403,7 @@ PROTO Human [
                 physics Physics {
                   density -1
                   mass 3.707500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     5.040000e-02 5.100000e-03 5.110000e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -410,6 +419,7 @@ PROTO Human [
           physics Physics {
             density -1
             mass 9.301400
+            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.339000e-01 3.510000e-02 1.412000e-01
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -540,6 +550,7 @@ PROTO Human [
                                   physics Physics {
                                     density -1
                                     mass 0.457500
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       8.920000e-04 5.470000e-04 1.340000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -555,6 +566,7 @@ PROTO Human [
                             physics Physics {
                               density -1
                               mass 0.607500
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 2.962000e-03 6.180000e-04 3.213000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -570,6 +582,7 @@ PROTO Human [
                       physics Physics {
                         density -1
                         mass 0.607500
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           2.962000e-03 6.180000e-04 3.213000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -585,6 +598,7 @@ PROTO Human [
                 physics Physics {
                   density -1
                   mass 2.032500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     1.194600e-02 4.121000e-03 1.340900e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -692,6 +706,7 @@ PROTO Human [
                                   physics Physics {
                                     density -1
                                     mass 0.457500
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       8.920000e-04 5.470000e-04 1.340000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -707,6 +722,7 @@ PROTO Human [
                             physics Physics {
                               density -1
                               mass 0.607500
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 2.962000e-03 6.180000e-04 3.213000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -722,6 +738,7 @@ PROTO Human [
                       physics Physics {
                         density -1
                         mass 0.607500
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           2.962000e-03 6.180000e-04 3.213000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -737,6 +754,7 @@ PROTO Human [
                 physics Physics {
                   density -1
                   mass 2.032500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     1.194600e-02 4.121000e-03 1.340900e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -752,6 +770,7 @@ PROTO Human [
           physics Physics {
             density -1
             mass 26.826600
+            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.474500e+00 7.555000e-01 1.431400e+00
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -767,6 +786,7 @@ PROTO Human [
     physics Physics {
       density -1
       mass 11.777000
+      centerOfMass [ 0.000000 0.000000 0.000000 ]
       inertiaMatrix [
         1.028000e-01 8.710000e-02 5.790000e-02
         0.000000e+00 0.000000e+00 0.000000e+00

--- a/tests/expected/HumanR2022a.proto
+++ b/tests/expected/HumanR2022a.proto
@@ -194,6 +194,7 @@ PROTO HumanR2022a [
                                   physics Physics {
                                     density -1
                                     mass 0.216600
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       1.000000e-04 2.000000e-04 1.000000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -209,6 +210,7 @@ PROTO HumanR2022a [
                             physics Physics {
                               density -1
                               mass 1.250000
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 1.400000e-03 3.900000e-03 4.100000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -224,6 +226,7 @@ PROTO HumanR2022a [
                       physics Physics {
                         density -1
                         mass 0.100000
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           1.000000e-03 1.000000e-03 1.000000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -239,6 +242,7 @@ PROTO HumanR2022a [
                 physics Physics {
                   density -1
                   mass 3.707500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     5.040000e-02 5.100000e-03 5.110000e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -254,6 +258,7 @@ PROTO HumanR2022a [
           physics Physics {
             density -1
             mass 9.301400
+            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.339000e-01 3.510000e-02 1.412000e-01
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -424,6 +429,7 @@ PROTO HumanR2022a [
                                   physics Physics {
                                     density -1
                                     mass 0.216600
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       1.000000e-04 2.000000e-04 1.000000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -445,6 +451,7 @@ PROTO HumanR2022a [
                             physics Physics {
                               density -1
                               mass 1.250000
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 1.400000e-03 3.900000e-03 4.100000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -460,6 +467,7 @@ PROTO HumanR2022a [
                       physics Physics {
                         density -1
                         mass 0.100000
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           1.000000e-03 1.000000e-03 1.000000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -475,6 +483,7 @@ PROTO HumanR2022a [
                 physics Physics {
                   density -1
                   mass 3.707500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     5.040000e-02 5.100000e-03 5.110000e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -490,6 +499,7 @@ PROTO HumanR2022a [
           physics Physics {
             density -1
             mass 9.301400
+            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.339000e-01 3.510000e-02 1.412000e-01
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -655,6 +665,7 @@ PROTO HumanR2022a [
                                   physics Physics {
                                     density -1
                                     mass 0.457500
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       8.920000e-04 5.470000e-04 1.340000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -670,6 +681,7 @@ PROTO HumanR2022a [
                             physics Physics {
                               density -1
                               mass 0.607500
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 2.962000e-03 6.180000e-04 3.213000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -685,6 +697,7 @@ PROTO HumanR2022a [
                       physics Physics {
                         density -1
                         mass 0.607500
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           2.962000e-03 6.180000e-04 3.213000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -700,6 +713,7 @@ PROTO HumanR2022a [
                 physics Physics {
                   density -1
                   mass 2.032500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     1.194600e-02 4.121000e-03 1.340900e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -835,6 +849,7 @@ PROTO HumanR2022a [
                                   physics Physics {
                                     density -1
                                     mass 0.457500
+                                    centerOfMass [ 0.000000 0.000000 0.000000 ]
                                     inertiaMatrix [
                                       8.920000e-04 5.470000e-04 1.340000e-03
                                       0.000000e+00 0.000000e+00 0.000000e+00
@@ -850,6 +865,7 @@ PROTO HumanR2022a [
                             physics Physics {
                               density -1
                               mass 0.607500
+                              centerOfMass [ 0.000000 0.000000 0.000000 ]
                               inertiaMatrix [
                                 2.962000e-03 6.180000e-04 3.213000e-03
                                 0.000000e+00 0.000000e+00 0.000000e+00
@@ -865,6 +881,7 @@ PROTO HumanR2022a [
                       physics Physics {
                         density -1
                         mass 0.607500
+                        centerOfMass [ 0.000000 0.000000 0.000000 ]
                         inertiaMatrix [
                           2.962000e-03 6.180000e-04 3.213000e-03
                           0.000000e+00 0.000000e+00 0.000000e+00
@@ -880,6 +897,7 @@ PROTO HumanR2022a [
                 physics Physics {
                   density -1
                   mass 2.032500
+                  centerOfMass [ 0.000000 0.000000 0.000000 ]
                   inertiaMatrix [
                     1.194600e-02 4.121000e-03 1.340900e-02
                     0.000000e+00 0.000000e+00 0.000000e+00
@@ -895,6 +913,7 @@ PROTO HumanR2022a [
           physics Physics {
             density -1
             mass 26.826600
+            centerOfMass [ 0.000000 0.000000 0.000000 ]
             inertiaMatrix [
               1.474500e+00 7.555000e-01 1.431400e+00
               0.000000e+00 0.000000e+00 0.000000e+00
@@ -910,6 +929,7 @@ PROTO HumanR2022a [
     physics Physics {
       density -1
       mass 11.777000
+      centerOfMass [ 0.000000 0.000000 0.000000 ]
       inertiaMatrix [
         1.028000e-01 8.710000e-02 5.790000e-02
         0.000000e+00 0.000000e+00 0.000000e+00

--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -219,9 +219,12 @@ def writeLinkPhysics(robotFile, link, level):
     robotFile.write((level + 1) * indent + 'physics Physics {\n')
     robotFile.write((level + 2) * indent + 'density -1\n')
     robotFile.write((level + 2) * indent + 'mass %lf\n' % link.inertia.mass)
-    robotFile.write((level + 2) * indent + 'centerOfMass [ %lf %lf %lf ]\n' % (link.inertia.position[0],
-                                                                               link.inertia.position[1],
-                                                                               link.inertia.position[2]))
+    if (link.inertia.position[0] != 0.0 and link.inertia.position[1] != 0.0 and link.inertia.position[2] != 0 or
+        (link.inertia.ixx > 0.0 or link.inertia.iyy > 0.0 or link.inertia.izz > 0.0 or link.inertia.ixy > 0.0 or
+         link.inertia.ixz > 0.0 or link.inertia.ixy > 0.0)):
+        robotFile.write((level + 2) * indent + 'centerOfMass [ %lf %lf %lf ]\n' % (link.inertia.position[0],
+                                                                                   link.inertia.position[1],
+                                                                                   link.inertia.position[2]))
     if link.inertia.ixx > 0.0 and link.inertia.iyy > 0.0 and link.inertia.izz > 0.0:
         i = link.inertia
         inertiaMatrix = [i.ixx, i.ixy, i.ixz, i.ixy, i.iyy, i.iyz, i.ixz, i.iyz, i.izz]

--- a/urdf2webots/writeRobot.py
+++ b/urdf2webots/writeRobot.py
@@ -219,10 +219,9 @@ def writeLinkPhysics(robotFile, link, level):
     robotFile.write((level + 1) * indent + 'physics Physics {\n')
     robotFile.write((level + 2) * indent + 'density -1\n')
     robotFile.write((level + 2) * indent + 'mass %lf\n' % link.inertia.mass)
-    if link.inertia.position[0] != 0.0 and link.inertia.position[1] != 0.0 and link.inertia.position[2] != 0:
-        robotFile.write((level + 2) * indent + 'centerOfMass [ %lf %lf %lf ]\n' % (link.inertia.position[0],
-                                                                                   link.inertia.position[1],
-                                                                                   link.inertia.position[2]))
+    robotFile.write((level + 2) * indent + 'centerOfMass [ %lf %lf %lf ]\n' % (link.inertia.position[0],
+                                                                               link.inertia.position[1],
+                                                                               link.inertia.position[2]))
     if link.inertia.ixx > 0.0 and link.inertia.iyy > 0.0 and link.inertia.izz > 0.0:
         i = link.inertia
         inertiaMatrix = [i.ixx, i.ixy, i.ixz, i.ixy, i.iyy, i.iyz, i.ixz, i.iyz, i.izz]


### PR DESCRIPTION
If the inertia matrix is provided, the center of mass must also be provided, even if it's at the default value. Otherwise warnings are shown.
