### PR TITLE
Use relative path in output when relative in urdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 /urdf2webots.egg-info
 /dist
+.vscode/launch.json
+.vscode/settings.json

--- a/tests/expected/Human.proto
+++ b/tests/expected/Human.proto
@@ -2,7 +2,7 @@
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # This is a proto file for Webots for the Human
-# Extracted from: root://tests/sources/gait2392_simbody/urdf/human.urdf
+# Extracted from: ../sources/gait2392_simbody/urdf/human.urdf
 
 PROTO Human [
   field  SFVec3f     translation     0 0 0
@@ -27,7 +27,7 @@ PROTO Human [
     selfCollision IS selfCollision
     children [
       DEF Pelvis_visual CadShape {
-        url "root://tests/sources/gait2392_simbody/meshes/obj/Pelvis.obj"
+        url "../sources/gait2392_simbody/meshes/obj/Pelvis.obj"
       }
       HingeJoint {
         jointParameters HingeJointParameters {
@@ -50,7 +50,7 @@ PROTO Human [
           translation -0.070700 0.083500 -0.066100
           children [
             DEF Femur_L_visual CadShape {
-              url "root://tests/sources/gait2392_simbody/meshes/obj/Femur L.obj"
+              url "../sources/gait2392_simbody/meshes/obj/Femur L.obj"
             }
             HingeJoint {
               jointParameters HingeJointParameters {
@@ -73,7 +73,7 @@ PROTO Human [
                 translation -0.004500 0.000000 -0.395821
                 children [
                   DEF Tibia_L_visual CadShape {
-                    url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia L.obj"
+                    url "../sources/gait2392_simbody/meshes/obj/Tibia L.obj"
                   }
                   HingeJoint {
                     jointParameters HingeJointParameters {
@@ -96,7 +96,7 @@ PROTO Human [
                       translation 0.000000 0.000000 -0.430000
                       children [
                         DEF Talus_L_visual CadShape {
-                          url "root://tests/sources/gait2392_simbody/meshes/obj/Talus L.obj"
+                          url "../sources/gait2392_simbody/meshes/obj/Talus L.obj"
                         }
                         HingeJoint {
                           jointParameters HingeJointParameters {
@@ -119,7 +119,7 @@ PROTO Human [
                             translation -0.048770 0.007920 -0.041950
                             children [
                               DEF Calcn_L_visual CadShape {
-                                url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.obj"
+                                url "../sources/gait2392_simbody/meshes/obj/Calcn L.obj"
                               }
                               HingeJoint {
                                 jointParameters HingeJointParameters {
@@ -142,12 +142,12 @@ PROTO Human [
                                   translation 0.178800 0.001080 -0.002000
                                   children [
                                     DEF Toes_L_visual CadShape {
-                                      url "root://tests/sources/gait2392_simbody/meshes/obj/Toes L.obj"
+                                      url "../sources/gait2392_simbody/meshes/obj/Toes L.obj"
                                     }
                                   ]
                                   name "toes_l"
                                   boundingObject DEF Toes_L_001 Mesh {
-                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Toes L.001.obj"
+                                    url "../sources/gait2392_simbody/meshes/obj/Toes L.001.obj"
                                   }
                                   physics Physics {
                                     density -1
@@ -163,7 +163,7 @@ PROTO Human [
                             ]
                             name "calcn_l"
                             boundingObject DEF Calcn_L_001 Mesh {
-                              url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
+                              url "../sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
                             }
                             physics Physics {
                               density -1
@@ -179,7 +179,7 @@ PROTO Human [
                       ]
                       name "talus_l"
                       boundingObject DEF Talus_L_001 Mesh {
-                        url "root://tests/sources/gait2392_simbody/meshes/obj/Talus L.001.obj"
+                        url "../sources/gait2392_simbody/meshes/obj/Talus L.001.obj"
                       }
                       physics Physics {
                         density -1
@@ -195,7 +195,7 @@ PROTO Human [
                 ]
                 name "tibia_l"
                 boundingObject DEF Tibia_L_001 Mesh {
-                  url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia L.001.obj"
+                  url "../sources/gait2392_simbody/meshes/obj/Tibia L.001.obj"
                 }
                 physics Physics {
                   density -1
@@ -211,7 +211,7 @@ PROTO Human [
           ]
           name "femur_l"
           boundingObject DEF Femur_L_001 Mesh {
-            url "root://tests/sources/gait2392_simbody/meshes/obj/Femur L.001.obj"
+            url "../sources/gait2392_simbody/meshes/obj/Femur L.001.obj"
           }
           physics Physics {
             density -1
@@ -244,7 +244,7 @@ PROTO Human [
           translation -0.070700 -0.083500 -0.066100
           children [
             DEF Femur_R_visual CadShape {
-              url "root://tests/sources/gait2392_simbody/meshes/obj/Femur R.obj"
+              url "../sources/gait2392_simbody/meshes/obj/Femur R.obj"
             }
             HingeJoint {
               jointParameters HingeJointParameters {
@@ -267,7 +267,7 @@ PROTO Human [
                 translation -0.004500 0.000000 -0.395821
                 children [
                   DEF Tibia_R_visual CadShape {
-                    url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia R.obj"
+                    url "../sources/gait2392_simbody/meshes/obj/Tibia R.obj"
                   }
                   HingeJoint {
                     jointParameters HingeJointParameters {
@@ -290,7 +290,7 @@ PROTO Human [
                       translation 0.000000 0.000000 -0.430000
                       children [
                         DEF Talus_R_visual CadShape {
-                          url "root://tests/sources/gait2392_simbody/meshes/obj/Talus R.obj"
+                          url "../sources/gait2392_simbody/meshes/obj/Talus R.obj"
                         }
                         HingeJoint {
                           jointParameters HingeJointParameters {
@@ -316,7 +316,7 @@ PROTO Human [
                                 scale 1.000000 -1.000000 1.000000
                                 children [
                                   DEF Calcn_L_visual_cw CadShape {
-                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.obj"
+                                    url "../sources/gait2392_simbody/meshes/obj/Calcn L.obj"
                                     ccw FALSE
                                   }
                                 ]
@@ -342,12 +342,12 @@ PROTO Human [
                                   translation 0.178800 -0.001080 -0.002000
                                   children [
                                     DEF Toes_R_visual CadShape {
-                                      url "root://tests/sources/gait2392_simbody/meshes/obj/Toes R.obj"
+                                      url "../sources/gait2392_simbody/meshes/obj/Toes R.obj"
                                     }
                                   ]
                                   name "toes_r"
                                   boundingObject DEF Toes_R_001 Mesh {
-                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Toes R.001.obj"
+                                    url "../sources/gait2392_simbody/meshes/obj/Toes R.001.obj"
                                   }
                                   physics Physics {
                                     density -1
@@ -366,7 +366,7 @@ PROTO Human [
                               scale 1.000000 -1.000000 1.000000
                               children [
                                 DEF Calcn_L_001_cw Mesh {
-                                  url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
+                                  url "../sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
                                   ccw FALSE
                                 }
                               ]
@@ -385,7 +385,7 @@ PROTO Human [
                       ]
                       name "talus_r"
                       boundingObject DEF Talus_R_001 Mesh {
-                        url "root://tests/sources/gait2392_simbody/meshes/obj/Talus R.001.obj"
+                        url "../sources/gait2392_simbody/meshes/obj/Talus R.001.obj"
                       }
                       physics Physics {
                         density -1
@@ -401,7 +401,7 @@ PROTO Human [
                 ]
                 name "tibia_r"
                 boundingObject DEF Tibia_R_001 Mesh {
-                  url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia R.001.obj"
+                  url "../sources/gait2392_simbody/meshes/obj/Tibia R.001.obj"
                 }
                 physics Physics {
                   density -1
@@ -417,7 +417,7 @@ PROTO Human [
           ]
           name "femur_r"
           boundingObject DEF Femur_R_001 Mesh {
-            url "root://tests/sources/gait2392_simbody/meshes/obj/Femur R.001.obj"
+            url "../sources/gait2392_simbody/meshes/obj/Femur R.001.obj"
           }
           physics Physics {
             density -1
@@ -451,7 +451,7 @@ PROTO Human [
           translation -0.100700 0.000000 0.081500
           children [
             DEF Torso_visual CadShape {
-              url "root://tests/sources/gait2392_simbody/meshes/obj/Torso.obj"
+              url "../sources/gait2392_simbody/meshes/obj/Torso.obj"
             }
             HingeJoint {
               jointParameters HingeJointParameters {
@@ -474,7 +474,7 @@ PROTO Human [
                 translation 0.003155 0.170000 0.371500
                 children [
                   DEF Humerus_L_visual CadShape {
-                    url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus L.obj"
+                    url "../sources/gait2392_simbody/meshes/obj/Humerus L.obj"
                   }
                   HingeJoint {
                     jointParameters HingeJointParameters {
@@ -497,7 +497,7 @@ PROTO Human [
                       translation 0.013144 -0.009595 -0.286273
                       children [
                         DEF Ulna_L_visual CadShape {
-                          url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna L.obj"
+                          url "../sources/gait2392_simbody/meshes/obj/Ulna L.obj"
                         }
                         HingeJoint {
                           jointParameters HingeJointParameters {
@@ -520,7 +520,7 @@ PROTO Human [
                             translation -0.006727 0.026083 -0.013007
                             children [
                               DEF Radius_L_visual CadShape {
-                                url "root://tests/sources/gait2392_simbody/meshes/obj/Radius L.obj"
+                                url "../sources/gait2392_simbody/meshes/obj/Radius L.obj"
                               }
                               HingeJoint {
                                 jointParameters HingeJointParameters {
@@ -543,12 +543,12 @@ PROTO Human [
                                   translation -0.008797 0.013610 -0.235841
                                   children [
                                     DEF Hand_L_visual CadShape {
-                                      url "root://tests/sources/gait2392_simbody/meshes/obj/Hand L.obj"
+                                      url "../sources/gait2392_simbody/meshes/obj/Hand L.obj"
                                     }
                                   ]
                                   name "hand_l"
                                   boundingObject DEF Hand_L_001 Mesh {
-                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Hand L.001.obj"
+                                    url "../sources/gait2392_simbody/meshes/obj/Hand L.001.obj"
                                   }
                                   physics Physics {
                                     density -1
@@ -564,7 +564,7 @@ PROTO Human [
                             ]
                             name "radius_l"
                             boundingObject DEF Radius_L_001 Mesh {
-                              url "root://tests/sources/gait2392_simbody/meshes/obj/Radius L.001.obj"
+                              url "../sources/gait2392_simbody/meshes/obj/Radius L.001.obj"
                             }
                             physics Physics {
                               density -1
@@ -580,7 +580,7 @@ PROTO Human [
                       ]
                       name "ulna_l"
                       boundingObject DEF Ulna_L_001 Mesh {
-                        url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna L.001.obj"
+                        url "../sources/gait2392_simbody/meshes/obj/Ulna L.001.obj"
                       }
                       physics Physics {
                         density -1
@@ -596,7 +596,7 @@ PROTO Human [
                 ]
                 name "humerus_l"
                 boundingObject DEF Humerus_L_001 Mesh {
-                  url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus L.001.obj"
+                  url "../sources/gait2392_simbody/meshes/obj/Humerus L.001.obj"
                 }
                 physics Physics {
                   density -1
@@ -630,7 +630,7 @@ PROTO Human [
                 translation 0.003155 -0.170000 0.371500
                 children [
                   DEF Humerus_R_visual CadShape {
-                    url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus R.obj"
+                    url "../sources/gait2392_simbody/meshes/obj/Humerus R.obj"
                   }
                   HingeJoint {
                     jointParameters HingeJointParameters {
@@ -653,7 +653,7 @@ PROTO Human [
                       translation 0.013144 0.009595 -0.286273
                       children [
                         DEF Ulna_R_visual CadShape {
-                          url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna R.obj"
+                          url "../sources/gait2392_simbody/meshes/obj/Ulna R.obj"
                         }
                         HingeJoint {
                           jointParameters HingeJointParameters {
@@ -676,7 +676,7 @@ PROTO Human [
                             translation -0.006727 -0.026083 -0.013007
                             children [
                               DEF Radius_R_visual CadShape {
-                                url "root://tests/sources/gait2392_simbody/meshes/obj/Radius R.obj"
+                                url "../sources/gait2392_simbody/meshes/obj/Radius R.obj"
                               }
                               HingeJoint {
                                 jointParameters HingeJointParameters {
@@ -699,12 +699,12 @@ PROTO Human [
                                   translation -0.008797 -0.013610 -0.235841
                                   children [
                                     DEF Hand_R_visual CadShape {
-                                      url "root://tests/sources/gait2392_simbody/meshes/obj/Hand R.obj"
+                                      url "../sources/gait2392_simbody/meshes/obj/Hand R.obj"
                                     }
                                   ]
                                   name "hand_r"
                                   boundingObject DEF Hand_R_001 Mesh {
-                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Hand R.001.obj"
+                                    url "../sources/gait2392_simbody/meshes/obj/Hand R.001.obj"
                                   }
                                   physics Physics {
                                     density -1
@@ -720,7 +720,7 @@ PROTO Human [
                             ]
                             name "radius_r"
                             boundingObject DEF Radius_R_001 Mesh {
-                              url "root://tests/sources/gait2392_simbody/meshes/obj/Radius R.001.obj"
+                              url "../sources/gait2392_simbody/meshes/obj/Radius R.001.obj"
                             }
                             physics Physics {
                               density -1
@@ -736,7 +736,7 @@ PROTO Human [
                       ]
                       name "ulna_r"
                       boundingObject DEF Ulna_R_001 Mesh {
-                        url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna R.001.obj"
+                        url "../sources/gait2392_simbody/meshes/obj/Ulna R.001.obj"
                       }
                       physics Physics {
                         density -1
@@ -752,7 +752,7 @@ PROTO Human [
                 ]
                 name "humerus_r"
                 boundingObject DEF Humerus_R_001 Mesh {
-                  url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus R.001.obj"
+                  url "../sources/gait2392_simbody/meshes/obj/Humerus R.001.obj"
                 }
                 physics Physics {
                   density -1
@@ -768,7 +768,7 @@ PROTO Human [
           ]
           name "torso"
           boundingObject DEF Torso_001 Mesh {
-            url "root://tests/sources/gait2392_simbody/meshes/obj/Torso.001.obj"
+            url "../sources/gait2392_simbody/meshes/obj/Torso.001.obj"
           }
           physics Physics {
             density -1
@@ -784,7 +784,7 @@ PROTO Human [
     ]
     name IS name
     boundingObject DEF Pelvis_001 Mesh {
-      url "root://tests/sources/gait2392_simbody/meshes/obj/Pelvis.001.obj"
+      url "../sources/gait2392_simbody/meshes/obj/Pelvis.001.obj"
     }
     physics Physics {
       density -1

--- a/tests/expected/HumanR2022a.proto
+++ b/tests/expected/HumanR2022a.proto
@@ -2,7 +2,7 @@
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # This is a proto file for Webots for the HumanR2022a
-# Extracted from: root://tests/sources/gait2392_simbody/urdf/human.urdf
+# Extracted from: ../sources/gait2392_simbody/urdf/human.urdf
 
 PROTO HumanR2022a [
   field  SFVec3f     translation     0 0 0
@@ -33,7 +33,7 @@ PROTO HumanR2022a [
           metalness 0
         }
         geometry DEF Pelvis Mesh {
-          url "root://tests/sources/gait2392_simbody/meshes/obj/Pelvis.obj"
+          url "../sources/gait2392_simbody/meshes/obj/Pelvis.obj"
         }
       }
       HingeJoint {
@@ -63,7 +63,7 @@ PROTO HumanR2022a [
                 metalness 0
               }
               geometry DEF Femur_L Mesh {
-                url "root://tests/sources/gait2392_simbody/meshes/obj/Femur L.obj"
+                url "../sources/gait2392_simbody/meshes/obj/Femur L.obj"
               }
             }
             HingeJoint {
@@ -93,7 +93,7 @@ PROTO HumanR2022a [
                       metalness 0
                     }
                     geometry DEF Tibia_L Mesh {
-                      url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia L.obj"
+                      url "../sources/gait2392_simbody/meshes/obj/Tibia L.obj"
                     }
                   }
                   HingeJoint {
@@ -123,7 +123,7 @@ PROTO HumanR2022a [
                             metalness 0
                           }
                           geometry DEF Talus_L Mesh {
-                            url "root://tests/sources/gait2392_simbody/meshes/obj/Talus L.obj"
+                            url "../sources/gait2392_simbody/meshes/obj/Talus L.obj"
                           }
                         }
                         HingeJoint {
@@ -153,7 +153,7 @@ PROTO HumanR2022a [
                                   metalness 0
                                 }
                                 geometry DEF Calcn_L Mesh {
-                                  url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.obj"
+                                  url "../sources/gait2392_simbody/meshes/obj/Calcn L.obj"
                                 }
                               }
                               HingeJoint {
@@ -183,13 +183,13 @@ PROTO HumanR2022a [
                                         metalness 0
                                       }
                                       geometry DEF Toes_L Mesh {
-                                        url "root://tests/sources/gait2392_simbody/meshes/obj/Toes L.obj"
+                                        url "../sources/gait2392_simbody/meshes/obj/Toes L.obj"
                                       }
                                     }
                                   ]
                                   name "toes_l"
                                   boundingObject DEF Toes_L_001 Mesh {
-                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Toes L.001.obj"
+                                    url "../sources/gait2392_simbody/meshes/obj/Toes L.001.obj"
                                   }
                                   physics Physics {
                                     density -1
@@ -205,7 +205,7 @@ PROTO HumanR2022a [
                             ]
                             name "calcn_l"
                             boundingObject DEF Calcn_L_001 Mesh {
-                              url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
+                              url "../sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
                             }
                             physics Physics {
                               density -1
@@ -221,7 +221,7 @@ PROTO HumanR2022a [
                       ]
                       name "talus_l"
                       boundingObject DEF Talus_L_001 Mesh {
-                        url "root://tests/sources/gait2392_simbody/meshes/obj/Talus L.001.obj"
+                        url "../sources/gait2392_simbody/meshes/obj/Talus L.001.obj"
                       }
                       physics Physics {
                         density -1
@@ -237,7 +237,7 @@ PROTO HumanR2022a [
                 ]
                 name "tibia_l"
                 boundingObject DEF Tibia_L_001 Mesh {
-                  url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia L.001.obj"
+                  url "../sources/gait2392_simbody/meshes/obj/Tibia L.001.obj"
                 }
                 physics Physics {
                   density -1
@@ -253,7 +253,7 @@ PROTO HumanR2022a [
           ]
           name "femur_l"
           boundingObject DEF Femur_L_001 Mesh {
-            url "root://tests/sources/gait2392_simbody/meshes/obj/Femur L.001.obj"
+            url "../sources/gait2392_simbody/meshes/obj/Femur L.001.obj"
           }
           physics Physics {
             density -1
@@ -292,7 +292,7 @@ PROTO HumanR2022a [
                 metalness 0
               }
               geometry DEF Femur_R Mesh {
-                url "root://tests/sources/gait2392_simbody/meshes/obj/Femur R.obj"
+                url "../sources/gait2392_simbody/meshes/obj/Femur R.obj"
               }
             }
             HingeJoint {
@@ -322,7 +322,7 @@ PROTO HumanR2022a [
                       metalness 0
                     }
                     geometry DEF Tibia_R Mesh {
-                      url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia R.obj"
+                      url "../sources/gait2392_simbody/meshes/obj/Tibia R.obj"
                     }
                   }
                   HingeJoint {
@@ -352,7 +352,7 @@ PROTO HumanR2022a [
                             metalness 0
                           }
                           geometry DEF Talus_R Mesh {
-                            url "root://tests/sources/gait2392_simbody/meshes/obj/Talus R.obj"
+                            url "../sources/gait2392_simbody/meshes/obj/Talus R.obj"
                           }
                         }
                         HingeJoint {
@@ -385,7 +385,7 @@ PROTO HumanR2022a [
                                       metalness 0
                                     }
                                     geometry DEF Calcn_L_cw Mesh {
-                                      url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.obj"
+                                      url "../sources/gait2392_simbody/meshes/obj/Calcn L.obj"
                                       ccw FALSE
                                     }
                                   }
@@ -418,13 +418,13 @@ PROTO HumanR2022a [
                                         metalness 0
                                       }
                                       geometry DEF Toes_R Mesh {
-                                        url "root://tests/sources/gait2392_simbody/meshes/obj/Toes R.obj"
+                                        url "../sources/gait2392_simbody/meshes/obj/Toes R.obj"
                                       }
                                     }
                                   ]
                                   name "toes_r"
                                   boundingObject DEF Toes_R_001 Mesh {
-                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Toes R.001.obj"
+                                    url "../sources/gait2392_simbody/meshes/obj/Toes R.001.obj"
                                   }
                                   physics Physics {
                                     density -1
@@ -443,7 +443,7 @@ PROTO HumanR2022a [
                               scale 1.000000 -1.000000 1.000000
                               children [
                                 DEF Calcn_L_001_cw Mesh {
-                                  url "root://tests/sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
+                                  url "../sources/gait2392_simbody/meshes/obj/Calcn L.001.obj"
                                   ccw FALSE
                                 }
                               ]
@@ -462,7 +462,7 @@ PROTO HumanR2022a [
                       ]
                       name "talus_r"
                       boundingObject DEF Talus_R_001 Mesh {
-                        url "root://tests/sources/gait2392_simbody/meshes/obj/Talus R.001.obj"
+                        url "../sources/gait2392_simbody/meshes/obj/Talus R.001.obj"
                       }
                       physics Physics {
                         density -1
@@ -478,7 +478,7 @@ PROTO HumanR2022a [
                 ]
                 name "tibia_r"
                 boundingObject DEF Tibia_R_001 Mesh {
-                  url "root://tests/sources/gait2392_simbody/meshes/obj/Tibia R.001.obj"
+                  url "../sources/gait2392_simbody/meshes/obj/Tibia R.001.obj"
                 }
                 physics Physics {
                   density -1
@@ -494,7 +494,7 @@ PROTO HumanR2022a [
           ]
           name "femur_r"
           boundingObject DEF Femur_R_001 Mesh {
-            url "root://tests/sources/gait2392_simbody/meshes/obj/Femur R.001.obj"
+            url "../sources/gait2392_simbody/meshes/obj/Femur R.001.obj"
           }
           physics Physics {
             density -1
@@ -534,7 +534,7 @@ PROTO HumanR2022a [
                 metalness 0
               }
               geometry DEF Torso Mesh {
-                url "root://tests/sources/gait2392_simbody/meshes/obj/Torso.obj"
+                url "../sources/gait2392_simbody/meshes/obj/Torso.obj"
               }
             }
             HingeJoint {
@@ -564,7 +564,7 @@ PROTO HumanR2022a [
                       metalness 0
                     }
                     geometry DEF Humerus_L Mesh {
-                      url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus L.obj"
+                      url "../sources/gait2392_simbody/meshes/obj/Humerus L.obj"
                     }
                   }
                   HingeJoint {
@@ -594,7 +594,7 @@ PROTO HumanR2022a [
                             metalness 0
                           }
                           geometry DEF Ulna_L Mesh {
-                            url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna L.obj"
+                            url "../sources/gait2392_simbody/meshes/obj/Ulna L.obj"
                           }
                         }
                         HingeJoint {
@@ -624,7 +624,7 @@ PROTO HumanR2022a [
                                   metalness 0
                                 }
                                 geometry DEF Radius_L Mesh {
-                                  url "root://tests/sources/gait2392_simbody/meshes/obj/Radius L.obj"
+                                  url "../sources/gait2392_simbody/meshes/obj/Radius L.obj"
                                 }
                               }
                               HingeJoint {
@@ -654,13 +654,13 @@ PROTO HumanR2022a [
                                         metalness 0
                                       }
                                       geometry DEF Hand_L Mesh {
-                                        url "root://tests/sources/gait2392_simbody/meshes/obj/Hand L.obj"
+                                        url "../sources/gait2392_simbody/meshes/obj/Hand L.obj"
                                       }
                                     }
                                   ]
                                   name "hand_l"
                                   boundingObject DEF Hand_L_001 Mesh {
-                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Hand L.001.obj"
+                                    url "../sources/gait2392_simbody/meshes/obj/Hand L.001.obj"
                                   }
                                   physics Physics {
                                     density -1
@@ -676,7 +676,7 @@ PROTO HumanR2022a [
                             ]
                             name "radius_l"
                             boundingObject DEF Radius_L_001 Mesh {
-                              url "root://tests/sources/gait2392_simbody/meshes/obj/Radius L.001.obj"
+                              url "../sources/gait2392_simbody/meshes/obj/Radius L.001.obj"
                             }
                             physics Physics {
                               density -1
@@ -692,7 +692,7 @@ PROTO HumanR2022a [
                       ]
                       name "ulna_l"
                       boundingObject DEF Ulna_L_001 Mesh {
-                        url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna L.001.obj"
+                        url "../sources/gait2392_simbody/meshes/obj/Ulna L.001.obj"
                       }
                       physics Physics {
                         density -1
@@ -708,7 +708,7 @@ PROTO HumanR2022a [
                 ]
                 name "humerus_l"
                 boundingObject DEF Humerus_L_001 Mesh {
-                  url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus L.001.obj"
+                  url "../sources/gait2392_simbody/meshes/obj/Humerus L.001.obj"
                 }
                 physics Physics {
                   density -1
@@ -748,7 +748,7 @@ PROTO HumanR2022a [
                       metalness 0
                     }
                     geometry DEF Humerus_R Mesh {
-                      url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus R.obj"
+                      url "../sources/gait2392_simbody/meshes/obj/Humerus R.obj"
                     }
                   }
                   HingeJoint {
@@ -778,7 +778,7 @@ PROTO HumanR2022a [
                             metalness 0
                           }
                           geometry DEF Ulna_R Mesh {
-                            url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna R.obj"
+                            url "../sources/gait2392_simbody/meshes/obj/Ulna R.obj"
                           }
                         }
                         HingeJoint {
@@ -808,7 +808,7 @@ PROTO HumanR2022a [
                                   metalness 0
                                 }
                                 geometry DEF Radius_R Mesh {
-                                  url "root://tests/sources/gait2392_simbody/meshes/obj/Radius R.obj"
+                                  url "../sources/gait2392_simbody/meshes/obj/Radius R.obj"
                                 }
                               }
                               HingeJoint {
@@ -838,13 +838,13 @@ PROTO HumanR2022a [
                                         metalness 0
                                       }
                                       geometry DEF Hand_R Mesh {
-                                        url "root://tests/sources/gait2392_simbody/meshes/obj/Hand R.obj"
+                                        url "../sources/gait2392_simbody/meshes/obj/Hand R.obj"
                                       }
                                     }
                                   ]
                                   name "hand_r"
                                   boundingObject DEF Hand_R_001 Mesh {
-                                    url "root://tests/sources/gait2392_simbody/meshes/obj/Hand R.001.obj"
+                                    url "../sources/gait2392_simbody/meshes/obj/Hand R.001.obj"
                                   }
                                   physics Physics {
                                     density -1
@@ -860,7 +860,7 @@ PROTO HumanR2022a [
                             ]
                             name "radius_r"
                             boundingObject DEF Radius_R_001 Mesh {
-                              url "root://tests/sources/gait2392_simbody/meshes/obj/Radius R.001.obj"
+                              url "../sources/gait2392_simbody/meshes/obj/Radius R.001.obj"
                             }
                             physics Physics {
                               density -1
@@ -876,7 +876,7 @@ PROTO HumanR2022a [
                       ]
                       name "ulna_r"
                       boundingObject DEF Ulna_R_001 Mesh {
-                        url "root://tests/sources/gait2392_simbody/meshes/obj/Ulna R.001.obj"
+                        url "../sources/gait2392_simbody/meshes/obj/Ulna R.001.obj"
                       }
                       physics Physics {
                         density -1
@@ -892,7 +892,7 @@ PROTO HumanR2022a [
                 ]
                 name "humerus_r"
                 boundingObject DEF Humerus_R_001 Mesh {
-                  url "root://tests/sources/gait2392_simbody/meshes/obj/Humerus R.001.obj"
+                  url "../sources/gait2392_simbody/meshes/obj/Humerus R.001.obj"
                 }
                 physics Physics {
                   density -1
@@ -908,7 +908,7 @@ PROTO HumanR2022a [
           ]
           name "torso"
           boundingObject DEF Torso_001 Mesh {
-            url "root://tests/sources/gait2392_simbody/meshes/obj/Torso.001.obj"
+            url "../sources/gait2392_simbody/meshes/obj/Torso.001.obj"
           }
           physics Physics {
             density -1
@@ -924,7 +924,7 @@ PROTO HumanR2022a [
     ]
     name IS name
     boundingObject DEF Pelvis_001 Mesh {
-      url "root://tests/sources/gait2392_simbody/meshes/obj/Pelvis.001.obj"
+      url "../sources/gait2392_simbody/meshes/obj/Pelvis.001.obj"
     }
     physics Physics {
       density -1

--- a/tests/expected/RobotWithLocalMeshes.proto
+++ b/tests/expected/RobotWithLocalMeshes.proto
@@ -1,0 +1,47 @@
+#VRML_SIM R2022b utf8
+# license: Apache License 2.0
+# license url: http://www.apache.org/licenses/LICENSE-2.0
+# This is a proto file for Webots for the RobotWithLocalMeshes
+# Extracted from: RobotWithLocalMeshes.urdf
+
+PROTO RobotWithLocalMeshes [
+  field  SFVec3f     translation     0 0 0
+  field  SFRotation  rotation        0 0 1 0
+  field  SFString    name            "RobotWithLocalMeshes"  # Is `Robot.name`.
+  field  SFString    controller      "void"                  # Is `Robot.controller`.
+  field  MFString    controllerArgs  []                      # Is `Robot.controllerArgs`.
+  field  SFString    customData      ""                      # Is `Robot.customData`.
+  field  SFBool      supervisor      FALSE                   # Is `Robot.supervisor`.
+  field  SFBool      synchronization TRUE                    # Is `Robot.synchronization`.
+  field  SFBool      selfCollision   FALSE                   # Is `Robot.selfCollision`.
+]
+{
+  Robot {
+    translation IS translation
+    rotation IS rotation
+    controller IS controller
+    controllerArgs IS controllerArgs
+    customData IS customData
+    supervisor IS supervisor
+    synchronization IS synchronization
+    selfCollision IS selfCollision
+    children [
+      Solid {
+        children [
+          DEF part_1_visual_visual CadShape {
+            url "../sources/part_1_visual.obj"
+          }
+        ]
+        name "part_1"
+        boundingObject DEF part_1_collision Mesh {
+          url "../sources/part_1_collision.obj"
+        }
+        physics Physics {
+          density -1
+          mass 0.000000
+        }
+      }
+    ]
+    name IS name
+  }
+}

--- a/tests/sources/RobotWithLocalMeshes.urdf
+++ b/tests/sources/RobotWithLocalMeshes.urdf
@@ -1,0 +1,28 @@
+<robot name="onshape">
+  <link name="base_link"></link>
+  <joint name="base_link_to_base" type="fixed">
+    <parent link="base_link" />
+    <child link="part_1" />
+    <origin rpy="0.0 0 0" xyz="0 0 0" />
+  </joint>
+  <link name="part_1">
+    <!-- Shapes for part_4 -->
+    <visual>
+      <origin xyz="0 0 0" rpy="0 -0 0" />
+      <geometry>
+        <mesh filename="part_1_visual.obj" />
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 -0 0" />
+      <geometry>
+        <mesh filename="part_1_collision.obj" />
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <mass value="0" />
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0" />
+    </inertial>
+  </link>
+</robot>

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -47,6 +47,12 @@ modelPathsProto = [
         'output': os.path.join(resultDirectory, 'RobotWithDummyLink.proto'),
         'expected': [os.path.join(expectedDirectory, 'RobotWithDummyLink.proto')],
         'arguments': ''
+    },
+    {
+        'input': os.path.join(sourceDirectory, 'RobotWithLocalMeshes.urdf'),
+        'output': os.path.join(resultDirectory, 'RobotWithLocalMeshes.proto'),
+        'expected': [os.path.join(expectedDirectory, 'RobotWithLocalMeshes.proto')],
+        'arguments': ''
     }
 ]
 

--- a/urdf2webots/importer.py
+++ b/urdf2webots/importer.py
@@ -202,8 +202,10 @@ def convertUrdfContent(input, output=None, robotName=None, normal=False, boxColl
 
                 protoFile = open(outputFile, 'w')
                 urdf2webots.writeRobot.header(protoFile, urdfPath, robotName)
+                outputDirectory = os.path.dirname(os.path.abspath(outputFile))
             else:
                 tmp_robot_file = tempfile.NamedTemporaryFile(mode="w+", prefix='tempRobotURDFStringWebots')
+                outputDirectory = os.getcwd()
 
             urdf2webots.writeRobot.robotName = robotName
             urdf2webots.parserURDF.robotName = robotName  # pass robotName
@@ -229,7 +231,7 @@ def convertUrdfContent(input, output=None, robotName=None, normal=False, boxColl
             rootLink = urdf2webots.parserURDF.Link()
 
             for link in linkElementList:
-                linkList.append(urdf2webots.parserURDF.getLink(link, urdfDirectory))
+                linkList.append(urdf2webots.parserURDF.getLink(link, urdfDirectory, outputDirectory))
             for joint in jointElementList:
                 jointList.append(urdf2webots.parserURDF.getJoint(joint))
 


### PR DESCRIPTION
When there is a relative path in the urdf, use a relative path in the output
but make the path in the output refer to the file relative to the output
location.

Add a new test case and change an existing test case which was expecting
absolute paths in the output.