### PR TITLE
Prepare version 2023.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='urdf2webots',
-    version='2.0.3',
+    version='2023.1.0',
     author='Cyberbotics',
     author_email='support@cyberbotics.com',
     description='A converter between URDF and PROTO files.',


### PR DESCRIPTION
I could not find any information on the version naming. I think it would be good to match the version numbering of `webots_ros` and `webots_ros2` using the year, webots realease and minor value.